### PR TITLE
bug fix in code for merging OTU groups

### DIFF
--- a/peyotl/manip.py
+++ b/peyotl/manip.py
@@ -191,7 +191,7 @@ def merge_otus_and_trees(nexson_blob):
                                 break
                     if match_otu is not None:
                         id_to_replace_id[oid] = match_otu[0]
-                        used_matches = match_otu[0]
+                        used_matches.add(match_otu[0])
                         _merge_otu_do_not_fix_references(otu, match_otu[1])
                     else:
                         assert oid not in retained_og_otu


### PR DESCRIPTION
This is a bug fix that affects the behavior of the new study import in contexts in which there are multiple OTU blocks. I'll try to rerun the import on on files where we have external data to see if anything was affected. But that will take some scripting...
