### PR TITLE
this update of _study2shard_map should have had the mutex

### DIFF
--- a/peyotl/phylesystem/phylesystem_umbrella.py
+++ b/peyotl/phylesystem/phylesystem_umbrella.py
@@ -402,7 +402,8 @@ class _Phylesystem(_PhylesystemBase):
                 raise
         except:
             if placeholder_added:
-                del self._study2shard_map[new_study_id]
+                with self._index_lock:
+                    del self._study2shard_map[new_study_id]
             raise
         with self._index_lock:
             self._study2shard_map[new_study_id] = self._growing_shard


### PR DESCRIPTION
This could have been the cause of https://groups.google.com/forum/?fromgroups&hl=en#!topic/opentreeoflife-software/za6y_Gn6KzQ

This update of the study ID to shard map should have been inside a with...lock block.

I checked for regressions, and this seemed fine. But it is hard to test for an effect of this fix because the bugginess is lack of thread safety (and there is a good chance that rebooting would fix the problem for a while even if this is not the only bug).
