### PR TITLE
Issue 103

### DIFF
--- a/extras/dot_peyotl/config
+++ b/extras/dot_peyotl/config
@@ -10,6 +10,9 @@
 #       1.2.1 ("byId" HoneyBadgerFish)
 #repo_nexml2json = 1.2.1
 
+# The max_file_size is specified in bytes. the default is no size limit
+#max_file_size = 20000000
+
 
 [ott]
 # directory of holding ott. The directory name

--- a/peyotl/manip.py
+++ b/peyotl/manip.py
@@ -8,30 +8,11 @@ from peyotl.nexson_syntax import BY_ID_HONEY_BADGERFISH, \
                                  detect_nexson_version, \
                                  get_nexml_el, \
                                  _is_by_id_hbf
+# For backwards-comp we import count_num_trees which used to be
+#   defined here
+from peyotl.nexson_syntax.inspect import count_num_trees
 from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
-
-def count_num_trees(nexson, nexson_version=None):
-    if nexson_version is None:
-        nexson_version = detect_nexson_version(nexson)
-    nex = get_nexml_el(nexson)
-    num_trees_by_group = []
-    if _is_by_id_hbf(nexson_version):
-        for tree_group in nex.get('treesById', {}).values():
-            nt = len(tree_group.get('treeById', {}))
-            num_trees_by_group.append(nt)
-    else:
-        trees_group = nex.get('trees', [])
-        if isinstance(trees_group, dict):
-            trees_group = [trees_group]
-        for tree_group in trees_group:
-            t = tree_group.get('tree')
-            if isinstance(t, list):
-                nt = len(t)
-            else:
-                nt = 1
-            num_trees_by_group.append(nt)
-    return sum(num_trees_by_group)
 
 def iter_trees(nexson, nexson_version=None):
     '''generator over all trees in all trees elements.

--- a/peyotl/nexson_syntax/__init__.py
+++ b/peyotl/nexson_syntax/__init__.py
@@ -36,6 +36,7 @@ from peyotl.nexson_syntax.badgerfish2direct_nexson import Badgerfish2DirectNexso
 from peyotl.nexson_syntax.direct2badgerfish_nexson import Direct2BadgerfishNexson
 from peyotl.nexson_syntax.nexson2nexml import Nexson2Nexml
 from peyotl.nexson_syntax.nexml2nexson import Nexml2Nexson
+from peyotl.nexson_syntax.inspect import count_num_trees
 from peyotl.utility import get_logger
 import xml.dom.minidom
 import codecs

--- a/peyotl/nexson_syntax/inspect.py
+++ b/peyotl/nexson_syntax/inspect.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+'''Simple inspection of NexSON blob
+ Functions here should:
+    - work on any nexson version that peyotl supports and,
+    - avoid any coercion of the NexSON to another version.
+(unlike the functions in peyotl.manip, which may change the NexSON version)
+'''
+from __future__ import absolute_import, print_function, division
+from peyotl.nexson_syntax import detect_nexson_version, \
+                                 get_nexml_el, \
+                                 _is_by_id_hbf
+from peyotl.utility import get_logger
+_LOG = get_logger(__name__)
+
+def count_num_trees(nexson, nexson_version=None):
+    '''Returns the number of trees summed across all tree
+    groups.
+    '''
+    if nexson_version is None:
+        nexson_version = detect_nexson_version(nexson)
+    nex = get_nexml_el(nexson)
+    num_trees_by_group = []
+    if _is_by_id_hbf(nexson_version):
+        for tree_group in nex.get('treesById', {}).values():
+            nt = len(tree_group.get('treeById', {}))
+            num_trees_by_group.append(nt)
+    else:
+        trees_group = nex.get('trees', [])
+        if isinstance(trees_group, dict):
+            trees_group = [trees_group]
+        for tree_group in trees_group:
+            t = tree_group.get('tree')
+            if isinstance(t, list):
+                nt = len(t)
+            else:
+                nt = 1
+            num_trees_by_group.append(nt)
+    return sum(num_trees_by_group)

--- a/peyotl/nexson_validation/__init__.py
+++ b/peyotl/nexson_validation/__init__.py
@@ -7,7 +7,7 @@ from peyotl.nexson_validation.logger import FilteringLogger, \
                                             ValidationLogger
 from peyotl.nexson_validation.adaptor import create_validation_adaptor
 
-def validate_nexson(obj, warning_codes_to_skip=None, retain_deprecated=True):
+def validate_nexson(obj, warning_codes_to_skip=None, retain_deprecated=True, **kwargs):
     '''Takes an `obj` that is a NexSON object.
     `warning_codes_to_skip` is None or an iterable collection of integers
         that correspond to facets of NexsonWarningCodes. Warnings associated
@@ -28,19 +28,21 @@ def validate_nexson(obj, warning_codes_to_skip=None, retain_deprecated=True):
     else:
         v = ValidationLogger(store_messages=True)
     v.retain_deprecated = retain_deprecated
-    n = create_validation_adaptor(obj, v)
+    n = create_validation_adaptor(obj, v, **kwargs)
     return v, n
 
-def ot_validate(nexson):
+def ot_validate(nexson, **kwargs):
     '''Returns three objects:
         an annotation dict (NexSON formmatted),
         the validation_log object created when NexSON validation was performed, and
         the object of class NexSON which was created from nexson. This object may
             alias parts of the nexson dict that is passed in as an argument.
+
+    Currently the only kwargs used is 'max_num_trees_per_study'
     '''
     # stub function for hooking into NexSON validation
     codes_to_skip = [NexsonWarningCodes.UNVALIDATED_ANNOTATION] #pylint: disable=E1101
-    v_log, adaptor = validate_nexson(nexson, codes_to_skip)
+    v_log, adaptor = validate_nexson(nexson, codes_to_skip, **kwargs)
     annotation = v_log.prepare_annotation(author_name='api.opentreeoflife.org/validate',
                                           description='Open Tree NexSON validation')
     return annotation, v_log, adaptor

--- a/peyotl/nexson_validation/_badgerfish_validation.py
+++ b/peyotl/nexson_validation/_badgerfish_validation.py
@@ -18,11 +18,11 @@ from peyotl.nexson_validation._validation_base import NexsonValidationAdaptor
 from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
 class BadgerFishValidationAdaptor(NexsonValidationAdaptor):
-    def __init__(self, obj, logger):
+    def __init__(self, obj, logger, **kwargs):
         if not hasattr(self, '_syntax_version'):
             self._syntax_version = BADGER_FISH_NEXSON_VERSION
             self._find_first_literal_meta = find_val_for_first_bf_l_meta
-        NexsonValidationAdaptor.__init__(self, obj, logger)
+        NexsonValidationAdaptor.__init__(self, obj, logger, **kwargs)
 
     def _post_key_check_validate_otus_obj(self, og_nex_id, otus_group, vc):
         otu_dict = {}

--- a/peyotl/nexson_validation/_by_id_validation.py
+++ b/peyotl/nexson_validation/_by_id_validation.py
@@ -17,9 +17,9 @@ from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
 
 class ByIdHBFValidationAdaptor(NexsonValidationAdaptor):
-    def __init__(self, obj, logger):
+    def __init__(self, obj, logger, **kwargs):
         self._syntax_version = BY_ID_HONEY_BADGERFISH
-        NexsonValidationAdaptor.__init__(self, obj, logger)
+        NexsonValidationAdaptor.__init__(self, obj, logger, **kwargs)
     def _post_key_check_validate_otus_obj(self, og_nex_id, otus_group, vc):
         otu_obj = otus_group.get('otuById', {})
         if not isinstance(otu_obj, dict):

--- a/peyotl/nexson_validation/_validation_base.py
+++ b/peyotl/nexson_validation/_validation_base.py
@@ -4,6 +4,7 @@ from peyotl.nexson_validation.helper import SeverityCodes, _NEXEL, errorReturn
 from peyotl.nexson_validation.schema import add_schema_attributes
 from peyotl.nexson_validation.err_generator import factory2code, \
                                                    gen_MissingExpectedListWarning, \
+                                                   gen_MaxSizeExceededWarning, \
                                                    gen_MissingMandatoryKeyWarning, \
                                                    gen_MissingOptionalKeyWarning, \
                                                    gen_MultipleTipsToSameOttIdWarning, \
@@ -18,6 +19,7 @@ from peyotl.nexson_syntax.helper import add_literal_meta, \
                                         find_nested_meta_first, \
                                         extract_meta, \
                                         _add_value_to_dict_bf
+from peyotl.nexson_syntax.inspect import count_num_trees
 from peyotl.nexson_syntax import detect_nexson_version
 from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
@@ -334,7 +336,7 @@ class NexsonValidationAdaptor(NexsonAnnotationAdder): #pylint: disable=R0921
             assert self._nexson_version[:3] in ('0.0', '1.0', '1.2')
             self._validate_nexml_obj(self._nexml, vc, obj)
             if self._max_num_trees_per_study is not None:
-                nt = count_num_trees()
+                nt = count_num_trees(self._raw)
                 if nt > self._max_num_trees_per_study:
                     m = '{f:d} trees found, but a limit of {m:d} trees per nexson is being enforced'
                     m = m.format(f=nt, m=self._max_num_trees_per_study)

--- a/peyotl/nexson_validation/adaptor.py
+++ b/peyotl/nexson_validation/adaptor.py
@@ -13,23 +13,23 @@ from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
 
 class DirectHBFValidationAdaptor(BadgerFishValidationAdaptor):
-    def __init__(self, obj, logger):
+    def __init__(self, obj, logger, **kwargs):
         self._find_first_literal_meta = find_val_for_first_hbf_l_meta
         self._syntax_version = DIRECT_HONEY_BADGERFISH
-        BadgerFishValidationAdaptor.__init__(self, obj, logger)
+        BadgerFishValidationAdaptor.__init__(self, obj, logger, **kwargs)
 
-def create_validation_adaptor(obj, logger):
+def create_validation_adaptor(obj, logger, **kwargs):
     try:
         nexson_version = detect_nexson_version(obj)
     except:
-        return BadgerFishValidationAdaptor(obj, logger)
+        return BadgerFishValidationAdaptor(obj, logger, **kwargs)
     if _is_by_id_hbf(nexson_version):
         #_LOG.debug('validating as ById...')
-        return ByIdHBFValidationAdaptor(obj, logger)
+        return ByIdHBFValidationAdaptor(obj, logger, **kwargs)
     elif _is_badgerfish_version(nexson_version):
         #_LOG.debug('validating as BadgerFish...')
-        return BadgerFishValidationAdaptor(obj, logger)
+        return BadgerFishValidationAdaptor(obj, logger, **kwargs)
     elif _is_direct_hbf(nexson_version):
         #_LOG.debug('validating as DirectHBF...')
-        return DirectHBFValidationAdaptor(obj, logger)
+        return DirectHBFValidationAdaptor(obj, logger, **kwargs)
     raise NotImplementedError('nexml2json version {v}'.format(v=nexson_version))

--- a/peyotl/nexson_validation/warning_codes.py
+++ b/peyotl/nexson_validation/warning_codes.py
@@ -41,6 +41,7 @@ class NexsonWarningCodes(object):
               'UNREACHABLE_NODE',
               'INCORRECT_VALUE_TYPE',
               'MISSING_CRUCIAL_CONTENT',
+              'MAX_SIZE_EXCEEDED',
              )
     numeric_codes_registered = []
 # monkey-patching NexsonWarningCodes...

--- a/peyotl/phylesystem/git_actions.py
+++ b/peyotl/phylesystem/git_actions.py
@@ -97,7 +97,8 @@ class GitAction(object):
                  git_ssh=None,
                  pkey=None,
                  cache=None, #pylint: disable=W0613
-                 path_for_study_fn=None):
+                 path_for_study_fn=None,
+                 max_file_size=None):
         """Create a GitAction object to interact with a Git repository
 
         Example:
@@ -116,6 +117,7 @@ class GitAction(object):
         self.repo_remote = remote
         self.git_ssh = git_ssh
         self.pkey = pkey
+        self.max_file_size = max_file_size
 
         if os.path.isdir("{}/.git".format(self.repo)):
             self.gitdir = "--git-dir={}/.git".format(self.repo)

--- a/peyotl/phylesystem/git_workflows.py
+++ b/peyotl/phylesystem/git_workflows.py
@@ -144,6 +144,16 @@ def commit_and_try_merge2master(git_action,
         else:
             write_as_json(file_content, fc)
         fc.flush()
+        try:
+            max_file_size = git_action.max_file_size
+        except:
+            max_file_size = None
+        if max_file_size is not None:
+            file_size = os.stat(fc.name).st_size
+            if file_size > max_file_size:
+                m = 'Commit of study "{s}" had a file size ({a} bytes) which exceeds the maximum size allowed ({b} bytes).'
+                m = m.format(s=study_id, a=file_size, b=max_file_size)
+                raise GitWorkflowError(m)
         f = "Could not acquire lock to write to study #{s}".format(s=study_id)
         acquire_lock_raise(git_action, fail_msg=f)
         try:

--- a/peyotl/phylesystem/phylesystem_umbrella.py
+++ b/peyotl/phylesystem/phylesystem_umbrella.py
@@ -19,7 +19,9 @@ from peyotl.phylesystem.helper import get_repos, \
                                       _get_phylesystem_parent_with_source, \
                                       _make_phylesystem_cache_region
 
-from peyotl.phylesystem.phylesystem_shard import PhylesystemShardProxy, PhylesystemShard
+from peyotl.phylesystem.phylesystem_shard import PhylesystemShardProxy, \
+                                                 PhylesystemShard, \
+                                                 NotAPhylesystemShardError
 from peyotl.phylesystem.git_actions import GitAction
 from peyotl.phylesystem.git_workflows import commit_and_try_merge2master, \
                                              delete_study, \
@@ -176,9 +178,12 @@ class _Phylesystem(_PhylesystemBase):
                                          push_mirror_repo_path=push_mirror_repo_path,
                                          new_study_prefix=new_study_prefix,
                                          infrastructure_commit_author=infrastructure_commit_author)
-            except:
-                f = 'Git repo "{}" found in your phylesystem parent, but it does not appear to be a phylesystem shard. Please report this as a bug if this directory is supposed to be phylesystem shard.'
-                _LOG.warn(f.format(repo_filepath))
+            except NotAPhylesystemShardError as x:
+                f = 'Git repo "{d}" found in your phylesystem parent, but it does not appear to be a phylesystem shard. ' \
+                    'Please report this as a bug if this directory is supposed to be phylesystem shard. The triggering ' \
+                    'error message was:\n{e}'
+                f = f.format(d=repo_filepath, e=str(x))
+                _LOG.warn(f)
                 continue
             # if the mirror does not exist, clone it...
             if push_mirror_repos_par and (push_mirror_repo_path is None):

--- a/peyotl/test/support/helper.py
+++ b/peyotl/test/support/helper.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+from peyotl.utility.str_util import is_str_type
+import codecs
+import json
+
+def testing_read_json(fp):
+    return json.load(codecs.open(fp, 'r', encoding='utf-8'))
+def testing_write_json(o, fp):
+    with codecs.open(fp, 'w', encoding='utf-8') as fo:
+        json.dump(o, fo, indent=2, sort_keys=True)
+        fo.write('\n')
+def testing_through_json(d):
+    return json.loads(json.dumps(d))
+
+def testing_dict_eq(a, b):
+    if a == b:
+        return True
+    return False
+
+
+def testing_conv_key_unicode_literal(d):
+    r = {}
+    if not isinstance(d, dict):
+        return d
+    for k, v in d.items():
+        if isinstance(v, dict):
+            r[k] = testing_conv_key_unicode_literal(v)
+        elif isinstance(v, list):
+            r[k] = [testing_conv_key_unicode_literal(i) for i in v]
+        elif is_str_type(v) and v == 'unicode':
+            r[k] = 'str'
+        else:
+            r[k] = v
+    return r

--- a/peyotl/test/test_nexson_validate_lacking_otus.py
+++ b/peyotl/test/test_nexson_validate_lacking_otus.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 from peyotl.nexson_validation import validate_nexson
+from peyotl.test.support.helper import *
 from peyotl.test.support import pathmap
 from peyotl.utility import get_logger
 import unittest
@@ -11,33 +12,19 @@ _LOG = get_logger(__name__)
 # round trip filename tuples
 VALID_NEXSON_DIRS = ['9', 'otu', ]
 
-def read_json(fp):
-    return json.load(codecs.open(fp, 'r', encoding='utf-8'))
-def write_json(o, fp):
-    with codecs.open(fp, 'w', encoding='utf-8') as fo:
-        json.dump(o, fo, indent=2, sort_keys=True)
-        fo.write('\n')
-def through_json(d):
-    return json.loads(json.dumps(d))
-
-def dict_eq(a, b):
-    if a == b:
-        return True
-    return False
-
 class TestConvert(unittest.TestCase):
     def testInvalidFilesFail(self):
         msg = ''
         for fn in pathmap.all_files(os.path.join('nexson', 'lacking_otus')):
             if fn.endswith('.input'):
                 frag = fn[:-len('.input')]
-                inp = read_json(fn)
+                inp = testing_read_json(fn)
                 aa = validate_nexson(inp)
                 annot = aa[0]
                 if len(annot.errors) == 0:
                     ofn = pathmap.nexson_source_path(frag + '.output')
                     ew_dict = annot.get_err_warn_summary_dict()
-                    write_json(ew_dict, ofn)
+                    testing_write_json(ew_dict, ofn)
                     msg = "Failed to reject file. See {o}".format(o=str(msg))
                     self.assertTrue(False, msg)
 

--- a/peyotl/test/test_nexson_validation.py
+++ b/peyotl/test/test_nexson_validation.py
@@ -3,45 +3,16 @@ from peyotl.nexson_syntax import detect_nexson_version, get_empty_nexson
 from peyotl.utility.str_util import UNICODE, is_str_type
 from peyotl.nexson_validation import validate_nexson
 from peyotl.test.support import pathmap
+from peyotl.test.support.helper import *
 from peyotl.utility import get_logger
 import unittest
-import codecs
-import json
 import os
 _LOG = get_logger(__name__)
 
 # round trip filename tuples
 VALID_NEXSON_DIRS = ['9', 'otu', ]
 
-def read_json(fp):
-    with codecs.open(fp, 'r', encoding='utf-8') as fo:
-        return json.load(fo)
-def write_json(o, fp):
-    with codecs.open(fp, 'w', encoding='utf-8') as fo:
-        json.dump(o, fo, indent=2, sort_keys=True)
-        fo.write('\n')
-def through_json(d):
-    return json.loads(json.dumps(d))
 
-def dict_eq(a, b):
-    if a == b:
-        return True
-    return False
-
-def conv_key_unicode_literal(d):
-    r = {}
-    if not isinstance(d, dict):
-        return d
-    for k, v in d.items():
-        if isinstance(v, dict):
-            r[k] = conv_key_unicode_literal(v)
-        elif isinstance(v, list):
-            r[k] = [conv_key_unicode_literal(i) for i in v]
-        elif is_str_type(v) and v == 'unicode':
-            r[k] = 'str'
-        else:
-            r[k] = v
-    return r
 
 class TestConvert(unittest.TestCase):
     def testDetectVersion(self):
@@ -63,7 +34,7 @@ class TestConvert(unittest.TestCase):
                 if len(annot.errors) > 0:
                     ofn = pathmap.nexson_source_path(frag + '.output')
                     ew_dict = annot.get_err_warn_summary_dict()
-                    write_json(ew_dict, ofn)
+                    testing_write_json(ew_dict, ofn)
                     msg = "File failed to validate cleanly. See {o}".format(o=ofn)
                 self.assertEqual(len(annot.errors), 0, msg)
     def testInvalidFilesFail(self):
@@ -71,7 +42,7 @@ class TestConvert(unittest.TestCase):
         for fn in pathmap.all_files(os.path.join('nexson', 'invalid')):
             if fn.endswith('.input'):
                 frag = fn[:-len('.input')]
-                inp = read_json(fn)
+                inp = testing_read_json(fn)
                 try:
                     aa = validate_nexson(inp)
                 except:
@@ -80,7 +51,7 @@ class TestConvert(unittest.TestCase):
                 if len(annot.errors) == 0:
                     ofn = pathmap.nexson_source_path(frag + '.output')
                     ew_dict = annot.get_err_warn_summary_dict()
-                    write_json(ew_dict, ofn)
+                    testing_write_json(ew_dict, ofn)
                     msg = "Failed to reject file. See {o}".format(o=str(msg))
                     self.assertTrue(False, msg)
     def testExpectedWarnings(self):
@@ -90,15 +61,15 @@ class TestConvert(unittest.TestCase):
                 frag = fn[:-len('.input')]
                 efn = frag + '.expected'
                 if os.path.exists(efn):
-                    inp = read_json(fn)
+                    inp = testing_read_json(fn)
                     aa = validate_nexson(inp)
                     annot = aa[0]
                     ew_dict = annot.get_err_warn_summary_dict()
-                    ew_dict = conv_key_unicode_literal(through_json(ew_dict))
-                    exp = conv_key_unicode_literal(read_json(efn))
-                    if not dict_eq(ew_dict, exp):
+                    ew_dict = testing_conv_key_unicode_literal(testing_through_json(ew_dict))
+                    exp = testing_conv_key_unicode_literal(testing_read_json(efn))
+                    if not testing_dict_eq(ew_dict, exp):
                         ofn = frag + '.output'
-                        write_json(ew_dict, ofn)
+                        testing_write_json(ew_dict, ofn)
                         msg = "Validation failed to produce expected outcome. Compare {o} and {e}".format(o=ofn, e=efn)
                     self.assertDictEqual(exp, ew_dict, msg)
                 else:
@@ -110,15 +81,15 @@ class TestConvert(unittest.TestCase):
                 frag = fn[:-len('.input')]
                 efn = frag + '.expected'
                 if os.path.exists(efn):
-                    inp = read_json(fn)
+                    inp = testing_read_json(fn)
                     aa = validate_nexson(inp)
                     annot = aa[0]
                     ew_dict = annot.get_err_warn_summary_dict()
-                    ew_dict = through_json(ew_dict)
-                    exp = read_json(efn)
-                    if not dict_eq(ew_dict, exp):
+                    ew_dict = testing_through_json(ew_dict)
+                    exp = testing_read_json(efn)
+                    if not testing_dict_eq(ew_dict, exp):
                         ofn = frag + '.output'
-                        write_json(ew_dict, ofn)
+                        testing_write_json(ew_dict, ofn)
                         msg = "Validation failed to produce expected outcome. Compare {o} and {e}".format(o=ofn, e=efn)
                     self.assertDictEqual(exp, ew_dict, msg)
                 else:

--- a/peyotl/test/test_ot_validate.py
+++ b/peyotl/test/test_ot_validate.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+from peyotl.nexson_validation import ot_validate
+from peyotl.test.support.helper import *
+from peyotl.test.support import pathmap
+from peyotl.utility import get_logger
+import unittest
+import codecs
+import json
+import os
+_LOG = get_logger(__name__)
+
+# round trip filename tuples
+VALID_NEXSON_DIRS = ['9', 'otu', ]
+
+
+class TestConvert(unittest.TestCase):
+
+    def testValidFilesPass(self):
+        format_list = ['1.0', '1.2']
+        msg = ''
+        TESTS_WITH_GT_ONE_TREE = ['9']
+        for d in TESTS_WITH_GT_ONE_TREE:
+            for nf in format_list:
+                frag = os.path.join(d, 'v{f}.json'.format(f=nf))
+                nexson = pathmap.nexson_obj(frag)
+                annotation, v_log, adaptor =  ot_validate(nexson)
+                self.assertTrue(annotation['annotationEvent']['@passedChecks'])
+                annotation, v_log, adaptor =  ot_validate(nexson, max_num_trees_per_study=1)
+                self.assertFalse(annotation['annotationEvent']['@passedChecks'])
+                
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -129,6 +129,13 @@ def _get_util_logger():
 
 _CONFIG = None
 _CONFIG_FN = None
+
+def _replace_default_config(cfg):
+    '''Only to be used internally for testing ! 
+    '''
+    global _CONFIG
+    _CONFIG = cfg
+
 def get_default_config_filename():
     global _CONFIG_FN
     if _CONFIG_FN is None:

--- a/standalone-tests.sh
+++ b/standalone-tests.sh
@@ -27,10 +27,17 @@ then
 fi
 
 sh dev/refresh_for_git_tests.sh
+if ! python standalone_tests/test_git_workflows.py tiny_max_file_size
+then
+    stf=$(expr $stf + 1)
+fi
+
+sh dev/refresh_for_git_tests.sh
 if ! python standalone_tests/test_phylesystem_mirror.py
 then
     stf=$(expr $stf + 1)
 fi
+
 cd peyotl/test/data/mini_par/mirror/mini_phyl
 git push -f GitHubRemote 2d59ab892ddb3d09d4b18c91470b8c1c4cca86dc:master
 cd -


### PR DESCRIPTION
This implements the peyotl side of https://github.com/OpenTreeOfLife/peyotl/issues/103
ot_validate takes a keyword argument: max_num_trees_per_study and will generate an error if the # of trees exceeds this.
There is a new peyotl configuration setting in the `[phylesystem]` section called `max_file_size` If set, and the write operation that creates a commit creates a file that exceeds this number of bytes, then the operation will fail (without locking the phylesystem). 