### PR TITLE
cleanup + bug fixes in unused API wrappers

### DIFF
--- a/peyotl/api/phylesystem_api.py
+++ b/peyotl/api/phylesystem_api.py
@@ -124,7 +124,7 @@ class _PhylesystemAPIWrapper(_WSWrapper):
             nexson = self.json_http_get(url)
             r = {'data': nexson}
         elif self._src_code == _GET_LOCAL:
-            nexson, sha = self.phylesystem_obj.return_study(study_id) #pylint: disable-msg=W0632
+            nexson, sha = self.phylesystem_obj.return_study(study_id) #pylint: disable=W0632
             r = {'data': nexson,
                  'sha': sha}
         else:

--- a/peyotl/api/taxomachine.py
+++ b/peyotl/api/taxomachine.py
@@ -390,7 +390,7 @@ class _TaxomachineAPIWrapper(_WSWrapper):
         else:
             anc = []
             prev = None
-            for a in reversed(child_taxon._taxonomic_lineage):
+            for resp in reversed(child_taxon._taxonomic_lineage):
                 ott_id = resp['ot:ottId']
                 curr = self._ott_id2taxon.get(ott_id)
                 if curr is None:

--- a/peyotl/api/taxon.py
+++ b/peyotl/api/taxon.py
@@ -117,12 +117,12 @@ class TaxonWrapper(object):
 
     def write_report(self, output):
         if self.taxomachine_wrapper:
-            output.write('Taxon info query was obtained from: {} \n'.format(elf.taxomachine_wrapper.endpoint))
+            output.write('Taxon info query was obtained from: {} \n'.format(self.taxomachine_wrapper.endpoint))
         if self.taxonomy:
             output.write('The taxonomic source is\n')
             output.write(' {}'.format(self.taxonomy.source))
             output.write(' by {}\n'.format(self.taxonomy.author))
-            output.write('Information for the taxonomy can be found at {}\n'.format(result.taxonomy.weburl))
+            output.write('Information for the taxonomy can be found at {}\n'.format(self.taxonomy.weburl))
         output.write('OTT ID (ot:ottId) = {}\n'.format(self.ott_id))
         output.write('    name (ot:ottTaxonName) = "{}"\n'.format(self.name))
         output.write('    is a junior synonym ? {}\n'.format(bool(self.is_synonym)))
@@ -139,6 +139,11 @@ class TaxonWrapper(object):
         if self.nomenclature_code:
             output.write('    The nomenclatural code for this name is: {}\n'.format(self.nomenclature_code))
         if self.taxomachine_node_id:
-            output.write('    The (unstable) node ID in the current taxomachine instance is: {}\n'.format(self.taxomachine_node_id))
+            f = '    The (unstable) node ID in the current taxomachine instance is: {}\n'
+            f = f.format(self.taxomachine_node_id)
+            output.write(f)
         if self.treemachine_node_id:
-            output.write('    The (unstable) node ID in the current treemachine instance is: {}\n'.format(self.treemachine_node_id))
+            f = '    The (unstable) node ID in the current treemachine instance is: {}\n'
+            f = f.format(self.treemachine_node_id)
+            output.write(f)
+

--- a/peyotl/api/treemachine.py
+++ b/peyotl/api/treemachine.py
@@ -13,7 +13,7 @@ def _treemachine_tax_source2dict(tax_source):
         return d
     r = [i.strip() for i in tax_source.split(',')]
     for el in r:
-        k,v = el.split(':')
+        k, v = el.split(':')
         d[k] = v
     return d
 

--- a/peyotl/api/wrapper.py
+++ b/peyotl/api/wrapper.py
@@ -234,7 +234,8 @@ class _TNRSServicesWrapper(object):
     def endpoint(self):
         return self.taxomachine.endpoint
     def match_names(self, *valist, **kwargs):
-        '''performs taxonomic name resolution. See https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs#match_names
+        '''performs taxonomic name resolution.
+        See https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs#match_names
         with the exception that "ids" in the API call is referred has the name "id_list" in this function.
         The most commonly used kwargs are:
             - context_name=<name> (see contexts and infer_context methods)

--- a/peyotl/evaluate_tree.py
+++ b/peyotl/evaluate_tree.py
@@ -24,7 +24,6 @@ def evaluate_tree_rooting(nexson, ott, tree_proxy):
     if not has_phylo_groupings:
         return None
     id2bit = pruned_phylo.add_bits4subtree_ids(None)
-    bit2id = reverse_dict(id2bit)
     taxo_tree.add_bits4subtree_ids(id2bit)
     assert taxo_tree.root.bits4subtree_ids == pruned_phylo.root.bits4subtree_ids
     taxo_nontriv_splits = taxo_tree.bits2internal_node
@@ -32,12 +31,10 @@ def evaluate_tree_rooting(nexson, ott, tree_proxy):
     #_LOG.debug('taxo_nontriv_splits = {}'.format(taxo_nontriv_splits))
     # might want to copy this dict rather than modify in place..
     del taxo_nontriv_splits[taxon_mask] # root bitmask is trivial
-    num_inf_taxo = len(taxo_nontriv_splits)
     _LOG.debug('taxon_mask = {} (which is {} bits)'.format(bin(taxon_mask)[2:], len(bin(taxon_mask)) - 2))
     num_ids = len(id2bit)
     _LOG.debug('id2bit has length = {}'.format(len(id2bit)))
-    incompat_taxo_splits = {}
-    #for checking tips of the phylogeny, it is nice to know which leaf OTUs attach 
+    #for checking tips of the phylogeny, it is nice to know which leaf OTUs attach
     #   at the base of the taxonomy (no other grouping)
     basal_taxo = set()
     basal_bits = 0
@@ -214,3 +211,4 @@ def _check_for_opt_score(entity, best, best_list):
 def _get_cached_set(s, dict_frozensets):
     fs = frozenset(s)
     return dict_frozensets.setdefault(fs, fs)
+

--- a/peyotl/nexson_syntax/__init__.py
+++ b/peyotl/nexson_syntax/__init__.py
@@ -985,7 +985,7 @@ def extract_otu_nexson(nexson, otu_id, curr_version):
     return None
 
 def cull_nonmatching_trees(nexson, tree_id, curr_version=None):
-    '''Modifies `nexson` and returns it in version 1.2.1 
+    '''Modifies `nexson` and returns it in version 1.2.1
     with any tree that does not match the ID removed.
 
     Note that this does not search through the NexSON for

--- a/peyotl/nexson_validation/_badgerfish_validation.py
+++ b/peyotl/nexson_validation/_badgerfish_validation.py
@@ -285,7 +285,7 @@ class BadgerFishValidationAdaptor(NexsonValidationAdaptor):
                                   key_list=['ot:isLeaf'])
                 return errorReturn('"ot:isLeaf" for internal')
             finally:
-              vc.pop_context()
+                vc.pop_context()
         self._detect_multilabelled_tree(otus_group_id,
                                         tree_nex_id,
                                         otuid2leaf)

--- a/peyotl/nexson_validation/_by_id_validation.py
+++ b/peyotl/nexson_validation/_by_id_validation.py
@@ -262,15 +262,15 @@ class ByIdHBFValidationAdaptor(NexsonValidationAdaptor):
             return errorReturn('root node not labelled as root')
         vc.push_context(_NEXEL.INTERNAL_NODE, (tree_obj, tree_nex_id))
         try:
-          if not self._validate_internal_node_list(internal_nodes, vc):
-              return False
+            if not self._validate_internal_node_list(internal_nodes, vc):
+                return False
         finally:
             vc.pop_context()
         edges = [i for i in edge_dict.items()]
         vc.push_context(_NEXEL.EDGE, (tree_obj, tree_nex_id))
         try:
             if not self._validate_edge_list(edges, vc):
-              return False
+                return False
         finally:
             vc.pop_context()
         otuid2leaf = {}

--- a/peyotl/phylesystem/phylesystem_shard.py
+++ b/peyotl/phylesystem/phylesystem_shard.py
@@ -158,7 +158,8 @@ class PhylesystemShard(PhylesystemShardBase):
                 try:
                     max_file_size = int(max_file_size)
                 except:
-                    m = 'Configuration-base value of max_file_size was "{}". Expecting and integer.'.format(max_file_size)
+                    m = 'Configuration-base value of max_file_size was "{}". Expecting and integer.'
+                    m = m.format(max_file_size)
                     raise RuntimeError(m)
         self.max_file_size = max_file_size
         self.repo_nexml2json = repo_nexml2json
@@ -348,12 +349,13 @@ class PhylesystemShard(PhylesystemShardBase):
             self._study_index[study_id] = (self.name, self.study_dir, fp)
 
     def _create_git_action_for_mirror(self):
+        # If a study makes it into the working dir, we don't want to reject it from the mirror, so
+        #   we use max_file_size= None
         mirror_ga = self._ga_class(repo=self.push_mirror_repo_path,
                                    git_ssh=self.git_ssh,
                                    pkey=self.pkey,
                                    path_for_study_fn=self.filepath_for_study_id_fn,
-                                   max_file_size=None # If a study makes it into the working dir, we don't want to reject it from the mirror
-                                   )
+                                   max_file_size=None)
         return mirror_ga
 
     def push_to_remote(self, remote_name):

--- a/peyotl/phylesystem/phylesystem_umbrella.py
+++ b/peyotl/phylesystem/phylesystem_umbrella.py
@@ -179,9 +179,9 @@ class _Phylesystem(_PhylesystemBase):
                                          new_study_prefix=new_study_prefix,
                                          infrastructure_commit_author=infrastructure_commit_author)
             except NotAPhylesystemShardError as x:
-                f = 'Git repo "{d}" found in your phylesystem parent, but it does not appear to be a phylesystem shard. ' \
-                    'Please report this as a bug if this directory is supposed to be phylesystem shard. The triggering ' \
-                    'error message was:\n{e}'
+                f = 'Git repo "{d}" found in your phylesystem parent, but it does not appear to be a phylesystem ' \
+                    'shard. Please report this as a bug if this directory is supposed to be phylesystem shard. '\
+                    'The triggering error message was:\n{e}'
                 f = f.format(d=repo_filepath, e=str(x))
                 _LOG.warn(f)
                 continue

--- a/peyotl/test/test_evaluate_tree.py
+++ b/peyotl/test/test_evaluate_tree.py
@@ -27,7 +27,6 @@ class TestProxy(unittest.TestCase):
         ott = OTT()
         phylo = self.np.get_tree(tree_id='tree324')
         evaluate_tree_rooting(self.nexson, ott, phylo)
-        
 
 if __name__ == "__main__":
     unittest.main()

--- a/peyotl/test/test_nexson_validation.py
+++ b/peyotl/test/test_nexson_validation.py
@@ -1,9 +1,13 @@
 #! /usr/bin/env python
 from peyotl.nexson_syntax import detect_nexson_version, get_empty_nexson
-from peyotl.utility.str_util import UNICODE, is_str_type
+from peyotl.utility.str_util import UNICODE
 from peyotl.nexson_validation import validate_nexson
 from peyotl.test.support import pathmap
-from peyotl.test.support.helper import *
+from peyotl.test.support.helper import testing_write_json, \
+                                       testing_read_json, \
+                                       testing_through_json, \
+                                       testing_dict_eq, \
+                                       testing_conv_key_unicode_literal
 from peyotl.utility import get_logger
 import unittest
 import os

--- a/peyotl/test/test_ot_validate.py
+++ b/peyotl/test/test_ot_validate.py
@@ -1,11 +1,8 @@
 #! /usr/bin/env python
 from peyotl.nexson_validation import ot_validate
-from peyotl.test.support.helper import *
 from peyotl.test.support import pathmap
 from peyotl.utility import get_logger
 import unittest
-import codecs
-import json
 import os
 _LOG = get_logger(__name__)
 
@@ -17,17 +14,15 @@ class TestConvert(unittest.TestCase):
 
     def testValidFilesPass(self):
         format_list = ['1.0', '1.2']
-        msg = ''
         TESTS_WITH_GT_ONE_TREE = ['9']
         for d in TESTS_WITH_GT_ONE_TREE:
             for nf in format_list:
                 frag = os.path.join(d, 'v{f}.json'.format(f=nf))
                 nexson = pathmap.nexson_obj(frag)
-                annotation, v_log, adaptor =  ot_validate(nexson)
+                annotation = ot_validate(nexson)[0]
                 self.assertTrue(annotation['annotationEvent']['@passedChecks'])
-                annotation, v_log, adaptor =  ot_validate(nexson, max_num_trees_per_study=1)
+                annotation = ot_validate(nexson, max_num_trees_per_study=1)[0]
                 self.assertFalse(annotation['annotationEvent']['@passedChecks'])
-                
 
 
 if __name__ == "__main__":

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -131,7 +131,7 @@ _CONFIG = None
 _CONFIG_FN = None
 
 def _replace_default_config(cfg):
-    '''Only to be used internally for testing ! 
+    '''Only to be used internally for testing !
     '''
     global _CONFIG
     _CONFIG = cfg

--- a/peyotl/utility/dict_wrapper.py
+++ b/peyotl/utility/dict_wrapper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 class DictWrapper(object):
+    #pylint: disable=E1101
     def __init__(self, d):
         assert '_raw_dict' not in d # this would mess up the hacky __getattr__
         object.__setattr__(self, '_raw_dict', d)
@@ -21,6 +22,8 @@ class DictWrapper(object):
     def __contains__(self, key):
         return key in self._raw_dict
 class DictAttrWrapper(DictWrapper):
+    def __init__(self, d):
+        DictWrapper.__init__(self, d)
     def __setattr__(self, key, value):
         self._raw_dict[key] = value
     def __getattr__(self, key):
@@ -39,7 +42,7 @@ class FrozenDictWrapper(DictWrapper):
 
 class FrozenDictAttrWrapper(DictAttrWrapper):
     def __init__(self, d):
-        DictWrapper.__init__(self, d)
+        DictAttrWrapper.__init__(self, d)
     def __setattr__(self, key, value):
         raise TypeError('A "frozen" class derived from FrozenDictAttrWrapper does not support rebinding keys')
     def __setitem__(self, key, value):


### PR DESCRIPTION
Thanks, pylint! the recently updated wrappers
around the taxonomy wrappers had some variable
name bugs that crept in from refactoring.
Clearly we need better tests.