### PR TITLE
better wrapping of OTT, improve API wrappers, and more tests. One bug fix for the (rare) case of newick strings that need unicode.

### DIFF
--- a/examples/graph-of-life/list-synth-sources.py
+++ b/examples/graph-of-life/list-synth-sources.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+'''Calls the treemachine services to get the list 
+of sources in the current synthetic tree
+'''
+from peyotl.sugar import treemachine
+import argparse
+import sys
+import os
+description = __doc__
+prog = os.path.split(sys.argv[0])[-1]
+parser = argparse.ArgumentParser(prog=prog, description=description)
+parser.add_argument('--fetch',
+                    action='store_true',
+                    default=False,
+                    required=False,
+                    help="download the newick for the source tree from treemachine")
+args = parser.parse_args(sys.argv[1:])
+download = args.fetch
+out = sys.stdout
+
+sources = treemachine.synthetic_tree_id_list
+for src in sources:
+    study_id, tree_id = src['study_id'], src.get('tree_id')
+    concat = '{}_{}'.format(study_id, tree_id)
+    out.write(concat)
+    if download:
+        if tree_id != 'taxonomy':
+            resp = treemachine.get_source_tree(study_id=study_id,
+                                                 tree_id=tree_id,
+                                                 git_sha=src['git_sha'])
+            newick = resp['newick']
+            out.write('\t')
+            out.write(str(newick))
+    out.write('\n')

--- a/examples/phylesystem/otu_mapping_tsv.py
+++ b/examples/phylesystem/otu_mapping_tsv.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+'''reports the number of unmapped OTUS (to stderr) and (for all mapped OTUs)
+reports the ^ot:originalLabel\t^ot:ottTaxonName to standard out
+'''
+from peyotl.phylesystem.phylesystem_umbrella import Phylesystem
+from peyotl.nexson_syntax import get_nexml_el
+from peyotl.manip import iter_otus
+from collections import defaultdict
+import argparse
+import codecs
+import sys
+import os
+description = __doc__
+prog = os.path.split(sys.argv[0])[-1]
+parser = argparse.ArgumentParser(prog=prog, description=description)
+parser.add_argument('output')
+args = parser.parse_args(sys.argv[1:])
+if os.path.exists(args.output):
+    sys.exit('{} already exists! Exiting...\n'.format(args.output))
+phy = Phylesystem()
+out = codecs.open(args.output, 'w', encoding='utf-8')
+num_unmapped = 0
+
+for study_id, n in phy.iter_study_objs():
+    for og, otu_id, otu in iter_otus(n):
+        if '^ot:ottTaxonName' in otu:
+            out.write(u'{s}\t{o}\t{r}\t{m}\n'.format(s=study_id,
+                                                    o=otu_id,
+                                                    r=otu['^ot:originalLabel'],
+                                                    m=otu['^ot:ottTaxonName']))
+        else:
+            num_unmapped += 1
+sys.stderr.write('{n:d} unmapped otus\n'.format(n=num_unmapped))

--- a/examples/process-ott/create-ncbi-to-ott.py
+++ b/examples/process-ott/create-ncbi-to-ott.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import pickle
+import sys
+import os
+if __name__ == '__main__':
+    from peyotl.ott import OTT
+    picklefn = sys.argv[1]
+    if os.path.exists(picklefn):
+        sys.exit('{} already exists'.format(picklefn))
+    ott = OTT()
+    ncbi2ott = {}
+    for ott_id, info in ott.ott_id_to_info.items():
+        ncbi = info.get('ncbi')
+        if ncbi is not None:
+            assert ncbi not in ncbi2ott
+            ncbi2ott[ncbi] = ott_id
+    with open(picklefn, 'wb') as fo:
+        pickle.dump(ncbi2ott, fo)

--- a/examples/process-ott/create-ncbi-to-ott.py
+++ b/examples/process-ott/create-ncbi-to-ott.py
@@ -4,6 +4,7 @@ import sys
 import os
 if __name__ == '__main__':
     from peyotl.ott import OTT
+    multimapping = set()
     picklefn = sys.argv[1]
     if os.path.exists(picklefn):
         sys.exit('{} already exists'.format(picklefn))
@@ -12,7 +13,16 @@ if __name__ == '__main__':
     for ott_id, info in ott.ott_id_to_info.items():
         ncbi = info.get('ncbi')
         if ncbi is not None:
-            assert ncbi not in ncbi2ott
-            ncbi2ott[ncbi] = ott_id
+            if ncbi in ncbi2ott:
+                prev = ncbi2ott[ncbi]
+                if isinstance(prev, list):
+                    prev.append(ott_id)
+                else:
+                    ncbi2ott[ncbi] = [prev, ott_id]
+                    multimapping.add(ncbi)
+            else:
+                ncbi2ott[ncbi] = ott_id
     with open(picklefn, 'wb') as fo:
         pickle.dump(ncbi2ott, fo)
+    if multimapping:
+        sys.stderr.write('{i:d} ncbi IDs mapped to multiple OTT IDs\n'.format(i=len(multimapping)))

--- a/maintainer-test.sh
+++ b/maintainer-test.sh
@@ -10,6 +10,11 @@ if ! ./standalone-tests.sh
 then
     k=1
 fi
+t=0
+if ! ./standalone-tests.sh
+then
+    t=1
+fi
 s=0
 if ! python setup.py test
 then
@@ -28,5 +33,11 @@ then
 else
     echo "Failed at least one standalone_test."
 fi
-exit $(expr $f + $k + $s)
+if test $t -eq 0
+then
+    echo "Passed all tutorial tests passed."
+else
+    echo "Failed at least one tutorial test"
+fi
+exit $(expr $f + $k + $s + $t)
 

--- a/peyotl/api/taxomachine.py
+++ b/peyotl/api/taxomachine.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from peyotl.utility.dict_wrapper import FrozenDictAttrWrapper, FrozenDictWrapper
-from peyotl.api.taxon import TaxonWrapper
+from peyotl.api.taxon import TaxonWrapper, TaxonHolder
 from peyotl.utility import get_config_object, get_logger
 from peyotl.api.wrapper import _WSWrapper, APIWrapper
 import weakref
@@ -9,17 +9,17 @@ _LOG = get_logger(__name__)
 _EMPTY_TUPLE = tuple()
 class TaxonomyInfoWrapper(FrozenDictAttrWrapper):
     pass
-class TNRSMatch(object):
+
+class TNRSMatch(TaxonHolder):
     '''Delegates to an TaxonWrapper object and adds score and is_approximate_match properties.
     part of a "wrapped" TNRS (or match_names) response.
     '''
     def __init__(self, prop_dict, taxomachine_wrapper=None, taxonomy=None, taxon=None):
-        if taxon is not None:
-            self._taxon = taxon
-        else:
-            self._taxon = TaxonWrapper(taxomachine_wrapper=taxomachine_wrapper,
-                                       taxonomy=taxonomy,
-                                       prop_dict=prop_dict)
+        if taxon is None:
+            taxon = TaxonWrapper(taxomachine_wrapper=taxomachine_wrapper,
+                                 taxonomy=taxonomy,
+                                 prop_dict=prop_dict)
+        TaxonHolder.__init__(self, taxon)
         self._score = prop_dict.get('score')
         self._is_approximate_match = prop_dict.get('is_approximate_match')
     @property

--- a/peyotl/api/taxomachine.py
+++ b/peyotl/api/taxomachine.py
@@ -26,30 +26,6 @@ class TNRSMatch(TaxonHolder):
     def ott_taxon_name(self):
         return self._taxon.ott_taxon_name
     @property
-    def name(self):
-        return self._taxon.ott_taxon_name
-    @property
-    def is_deprecated(self):
-        return self._taxon.is_deprecated
-    @property
-    def is_dubious(self):
-        return self._taxon.is_dubious
-    @property
-    def is_synonym(self):
-        return self._taxon.is_synonym
-    @property
-    def flags(self):
-        return self._taxon.flags
-    @property
-    def synonyms(self):
-        return self._taxon.synonyms
-    @property
-    def ott_id(self):
-        return self._taxon.ott_id
-    @property
-    def taxomachine_node_id(self):
-        return self._taxon.taxomachine_node_id
-    @property
     def rank(self):
         return self._taxon.rank
     @property

--- a/peyotl/api/taxomachine.py
+++ b/peyotl/api/taxomachine.py
@@ -26,15 +26,6 @@ class TNRSMatch(TaxonHolder):
     def ott_taxon_name(self):
         return self._taxon.ott_taxon_name
     @property
-    def rank(self):
-        return self._taxon.rank
-    @property
-    def unique_name(self):
-        return self._taxon.unique_name
-    @property
-    def nomenclature_code(self):
-        return self._taxon.nomenclature_code
-    @property
     def score(self):
         return self._score
     @property

--- a/peyotl/api/taxon.py
+++ b/peyotl/api/taxon.py
@@ -174,3 +174,12 @@ class TaxonHolder(object):
     @property
     def taxomachine_node_id(self):
         return self._taxon.taxomachine_node_id
+    @property
+    def rank(self):
+        return self._taxon.rank
+    @property
+    def unique_name(self):
+        return self._taxon.unique_name
+    @property
+    def nomenclature_code(self):
+        return self._taxon.nomenclature_code

--- a/peyotl/api/taxon.py
+++ b/peyotl/api/taxon.py
@@ -147,3 +147,30 @@ class TaxonWrapper(object):
             f = f.format(self.treemachine_node_id)
             output.write(f)
 
+class TaxonHolder(object):
+    def __init__(self, taxon):
+        self._taxon = taxon
+    @property
+    def name(self):
+        return self._taxon.ott_taxon_name
+    @property
+    def is_deprecated(self):
+        return self._taxon.is_deprecated
+    @property
+    def is_dubious(self):
+        return self._taxon.is_dubious
+    @property
+    def is_synonym(self):
+        return self._taxon.is_synonym
+    @property
+    def flags(self):
+        return self._taxon.flags
+    @property
+    def synonyms(self):
+        return self._taxon.synonyms
+    @property
+    def ott_id(self):
+        return self._taxon.ott_id
+    @property
+    def taxomachine_node_id(self):
+        return self._taxon.taxomachine_node_id

--- a/peyotl/api/treemachine.py
+++ b/peyotl/api/treemachine.py
@@ -2,7 +2,7 @@
 from peyotl.utility import get_config_object, get_logger
 from peyotl.api.wrapper import _WSWrapper, APIWrapper
 from peyotl.api.study_ref import StudyRef
-from peyotl.api.taxon import TaxonWrapper
+from peyotl.api.taxon import TaxonWrapper, TaxonHolder
 import anyjson
 _LOG = get_logger(__name__)
 _EMPTY_TUPLE = tuple()
@@ -17,7 +17,7 @@ def _treemachine_tax_source2dict(tax_source):
         d[k] = v
     return d
 
-class GoLNode(object):
+class GoLNode(TaxonHolder):
     def __init__(self,
                  prop_dict,
                  treemachine_wrapper=None,
@@ -31,9 +31,7 @@ class GoLNode(object):
             self._node_id = prop_dict['mrca_node_id']
         else:
             self._node_id = node_id
-        if taxon is not None:
-            self._taxon = taxon
-        else:
+        if taxon is None:
             oi = prop_dict.get('ott_id')
             if oi == 'null':
                 oi = None
@@ -45,9 +43,7 @@ class GoLNode(object):
                               'treemachine_node_id': self.node_id
                              }
                 #TODO should write wrappers for getting the taxomachine wrapper from treemachine wrapper...
-                self._taxon = TaxonWrapper(prop_dict=taxon_dict)
-            else:
-                self._taxon = None
+                taxon = TaxonWrapper(prop_dict=taxon_dict)
             if nearest_taxon is None:
                 taxon_dict = {'ot:ottId': prop_dict['nearest_taxon_mrca_ott_id'],
                               'rank': prop_dict.get('nearest_taxon_mrca_rank'),
@@ -60,6 +56,7 @@ class GoLNode(object):
                 self._nearest_taxon = TaxonWrapper(prop_dict=taxon_dict)
             else:
                 self._nearest_taxon = nearest_taxon
+        TaxonHolder.__init__(self, taxon)
         if self._taxon is not None:
             assert (nearest_taxon is None) or (nearest_taxon is self._taxon)
             self._nearest_taxon = self._taxon
@@ -137,30 +134,6 @@ class GoLNode(object):
     @property
     def is_taxon(self):
         return self._taxon is not None
-    @property
-    def name(self):
-        return self._taxon.ott_taxon_name
-    @property
-    def is_deprecated(self):
-        return self._taxon.is_deprecated
-    @property
-    def is_dubious(self):
-        return self._taxon.is_dubious
-    @property
-    def is_synonym(self):
-        return self._taxon.is_synonym
-    @property
-    def flags(self):
-        return self._taxon.flags
-    @property
-    def synonyms(self):
-        return self._taxon.synonyms
-    @property
-    def ott_id(self):
-        return self._taxon.ott_id
-    @property
-    def taxomachine_node_id(self):
-        return self._taxon.taxomachine_node_id
     @property
     def treemachine_node_id(self):
         return self._node_id

--- a/peyotl/api/treemachine.py
+++ b/peyotl/api/treemachine.py
@@ -137,15 +137,6 @@ class GoLNode(TaxonHolder):
     @property
     def treemachine_node_id(self):
         return self._node_id
-    @property
-    def rank(self):
-        return self._taxon.rank
-    @property
-    def unique_name(self):
-        return self._taxon.unique_name
-    @property
-    def nomenclature_code(self):
-        return self._taxon.nomenclature_code
 
 class MRCAGoLNode(GoLNode):
     def __init__(self, prop_dict, treemachine_wrapper=None, graph_of_life=None):

--- a/peyotl/manip.py
+++ b/peyotl/manip.py
@@ -13,6 +13,30 @@ from peyotl.nexson_syntax import BY_ID_HONEY_BADGERFISH, \
 from peyotl.nexson_syntax.inspect import count_num_trees
 from peyotl.utility import get_logger
 _LOG = get_logger(__name__)
+def iter_otus(nexson, nexson_version=None):
+    '''generator over all otus in all otus group elements.
+    yields a tuple of 3 items:
+        otus group ID,
+        otu ID,
+        the otu obj
+    '''
+    if nexson_version is None:
+        nexson_version = detect_nexson_version(nexson)
+    nex = get_nexml_el(nexson)
+    if not _is_by_id_hbf(nexson_version):
+        convert_nexson_format(nexson_blob, BY_ID_HONEY_BADGERFISH) #TODO shouldn't modify...
+    otus_group_by_id = nex['otusById']
+    group_order = nex.get('^ot:otusElementOrder', [])
+    if len(group_order) < len(otus_group_by_id):
+        group_order = list(otus_group_by_id.keys())
+        group_order.sort()
+    for otus_group_id in group_order:
+        otus_group = otus_group_by_id[otus_group_id]
+        otu_by_id = otus_group['otuById']
+        ti_order = list(otu_by_id.keys())
+        for otu_id in ti_order:
+            otu = otu_by_id[otu_id]
+            yield otus_group_id, otu_id, otu
 
 def iter_trees(nexson, nexson_version=None):
     '''generator over all trees in all trees elements.

--- a/peyotl/nexson_syntax/__init__.py
+++ b/peyotl/nexson_syntax/__init__.py
@@ -771,11 +771,11 @@ _NEWICK_NEEDING_QUOTING = re.compile(r'(\s|[\[\]():,;])')
 _NEXUS_NEEDING_QUOTING = re.compile(r'(\s|[-()\[\]{}/\,;:=*"`+<>])')
 
 def quote_newick_name(s, needs_quotes_pattern=_NEWICK_NEEDING_QUOTING):
-    s = str(s)
+    s = UNICODE(s)
     if "'" in s:
-        return "'{}'".format("''".join(s.split("'")))
+        return u"'{}'".format("''".join(s.split("'")))
     if needs_quotes_pattern.search(s):
-        return "'{}'".format(s)
+        return u"'{}'".format(s)
     return s
 
 def _write_newick_leaf_label(out, node, otu_group, label_key, leaf_labels, unlabeled_counter, needs_quotes_pattern):

--- a/peyotl/nexson_syntax/__init__.py
+++ b/peyotl/nexson_syntax/__init__.py
@@ -219,6 +219,10 @@ class PhyloSchema(object):
             'schema',
             'type_ext', then
             'output_nexml2json' (implicitly NexSON)
+            If exporting to a non-nexson format, `otu_label` (and then
+                `tip_label`are checked) to determine how to label the tips
+                'ot:originallabel', 'ot:ottid', and 'ot:otttaxonname'
+                are supported values
         '''
         self.content = kwargs.get('content', 'study')
         self.bracket_ingroup = bool(kwargs.get('bracket_ingroup', False))

--- a/peyotl/ott/__init__.py
+++ b/peyotl/ott/__init__.py
@@ -312,7 +312,7 @@ class OTT(object):
     def get_label(self, ott_id, name2label):
         n = self.get_name(ott_id)
         if name2label == OTULabelStyleEnum.CURRENT_LABEL_OTT_ID:
-            return '{n}_ott{o:d}'.format(n=n, o=ott_id)
+            return u'{n}_ott{o:d}'.format(n=n, o=ott_id)
         return n
     def get_name(self, ott_id):
         name_or_name_list = self.ott_id_to_names.get(ott_id)
@@ -732,11 +732,13 @@ def create_pruned_and_taxonomy_for_tip_ott_ids(tree_proxy, ott):
 
 if __name__ == '__main__':
     import sys
+    import codecs
+    out = codecs.getwriter('utf-8')(sys.stdout)
     o = OTT()
     #print('taxonomic sources = "{}"'.format('", "'.join([iii for iii in o.taxonomic_sources])))
     #print(o.ncbi(1115784))
-    o.write_newick(sys.stdout, label_style=OTULabelStyleEnum.CURRENT_LABEL_OTT_ID, prune_flags=_TREEMACHINE_PRUNE_FLAGS)
-    sys.stdout.write('\n')
+    o.write_newick(out, label_style=OTULabelStyleEnum.CURRENT_LABEL_OTT_ID, prune_flags=_TREEMACHINE_PRUNE_FLAGS)
+    out.write('\n')
     '''fstrs = ['{k:d}: {v}'.format(k=k, v=v) for k, v in o.flag_set_id_to_flag_set.items()]
     print('flag_set_id_to_flag_set =\n  {}'.format('\n  '.join(fstrs)))
     for ott_id, info in o.ott_id_to_info.items():

--- a/peyotl/ott/__init__.py
+++ b/peyotl/ott/__init__.py
@@ -570,10 +570,10 @@ if __name__ == '__main__':
     print('taxonomic sources = "{}"'.format('", "'.join([i for i in o.taxonomic_sources])))
     fstrs = ['{k:d}: {v}'.format(k=k, v=v) for k, v in o.flag_set_id_to_flag_set.items()]
     print('flag_set_id_to_flag_set =\n  {}'.format('\n  '.join(fstrs)))
-    for ott_id, info in o.ott_id_to_info.items():
+    '''for ott_id, info in o.ott_id_to_info.items():
         if 'ncbi' in info:
             print('OTT {o:d} => NCBI {n:d}'.format(o=ott_id, n=info['ncbi']))
-    '''print(len(o.ott_id2par_ott_id), 'ott IDs')
+    print(len(o.ott_id2par_ott_id), 'ott IDs')
     print('call')
     print(o.get_anc_lineage(593937)) # This is the OTT id of a species in the Asterales system
     print(o.root_name)

--- a/peyotl/ott/__init__.py
+++ b/peyotl/ott/__init__.py
@@ -255,6 +255,7 @@ class OTT(object):
                     fsi = f_set_id
                     f_set_id += 1
                     flag_set_id2flag_set[fsi] = f_set
+                    flag_set2flag_set_id[f_set] = fsi
                 info['f'] = fsi
             if info:
                 id2info[uid] = info
@@ -308,6 +309,7 @@ class OTT(object):
                         fsi = f_set_id
                         f_set_id += 1
                         flag_set_id2flag_set[fsi] = f_set
+                        flag_set2flag_set_id[f_set] = fsi
                     info['f'] = fsi
                 if info:
                     id2info[uid] = info

--- a/peyotl/phylo/tree.py
+++ b/peyotl/phylo/tree.py
@@ -448,6 +448,7 @@ class TreeWithPathsInEdges(_TreeWithNodeIDs):
             #_LOG.debug('while add bitrep... self.bits2internal_node = {}'.format(self.bits2internal_node))
             p.bits4subtree_ids |= node.bits4subtree_ids
         return relevant_ids
+
 def create_tree_from_id2par(id2par, id_list, _class=TreeWithPathsInEdges):
     if not id_list:
         return None

--- a/peyotl/utility/dict_wrapper.py
+++ b/peyotl/utility/dict_wrapper.py
@@ -21,6 +21,8 @@ class DictWrapper(object):
         self._raw_dict[key] = value
     def __contains__(self, key):
         return key in self._raw_dict
+    def __str__(self):
+        return '{c}({d})'.format(c=self.__class__.__name__, d=str(self._raw_dict))
 class DictAttrWrapper(DictWrapper):
     def __init__(self, d):
         DictWrapper.__init__(self, d)

--- a/tutorial-tests.sh
+++ b/tutorial-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -x
+ttf=0
+if ! python tutorials/ot-tnrs-match-names.py Hominidae >tutorials/tutorial-test-output 2>tutorials/tutorial-test-err-output
+then
+    ttf=$(expr $ttf + 1)
+    cat tutorials/tutorial-test-err-output
+fi
+if ! python tutorials/ot-taxon-info.py 770311 >tutorials/tutorial-test-output 2>tutorials/tutorial-test-err-output
+then
+    ttf=$(expr $ttf + 1)
+    cat tutorials/tutorial-test-err-output
+fi
+
+if ! python tutorials/ot-oti-find-tree.py '{"ot:ottId": 84761}' >tutorials/tutorial-test-output 2>tutorials/tutorial-test-err-output
+then
+    ttf=$(expr $ttf + 1)
+    cat tutorials/tutorial-test-err-output
+fi
+if ! python tutorials/ot-tree-of-life-mrca.py 770311 >tutorials/tutorial-test-output 2>tutorials/tutorial-test-err-output
+then
+    ttf=$(expr $ttf + 1)
+    cat tutorials/tutorial-test-err-output
+fi
+
+if test $ttf -gt 0
+then
+    echo "Failed at least one tutorial test"
+    exit $ttf
+else
+    echo "Passed all tutorial tests passed."
+fi

--- a/tutorials/.gitignore
+++ b/tutorials/.gitignore
@@ -1,0 +1,2 @@
+tutorial-test-output
+tutorial-test-err-output

--- a/tutorials/ot-taxon-subtree.py
+++ b/tutorials/ot-taxon-subtree.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+'''Simple command-line tool for reporting information a subtree of the OTT reference taxonomy using
+    which is described at https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs#subtree
+'''
+import sys
+
+def fetch_and_write_taxon_subtree(ott_id, output):
+    from peyotl.sugar import taxonomy
+    subtree = taxonomy.subtree(ott_id)['subtree']
+    output.write(subtree)
+    output.write('\n')
+
+
+def main(argv):
+    '''This function sets up a command-line option parser and then calls match_and_print
+    to do all of the real work.
+    '''
+    import argparse
+    description = 'Uses Open Tree of Life web services to find information for each OTT ID.'
+    parser = argparse.ArgumentParser(prog='ot-taxon-info', description=description)
+    parser.add_argument('ids', nargs='+', type=int, help='OTT IDs')
+    args = parser.parse_args(argv)
+    id_list = args.ids
+    for ott_id in id_list:
+        fetch_and_write_taxon_subtree(ott_id, sys.stdout)
+    
+if __name__ == '__main__':
+    try:
+        main(sys.argv[1:])
+    except Exception, x:
+        sys.exit('{}\n'.format(str(x)))
+

--- a/tutorials/ot-tree-of-life-mrca.py
+++ b/tutorials/ot-tree-of-life-mrca.py
@@ -26,7 +26,7 @@ def fetch_and_write_mrca(id_list, details, subtree, induced_subtree, output, err
 
     if details:
         # could call mrca_node.fetch_node_info()
-        errstream.write('Source(s) that support this node: {}\n'.format(mrca_node.synth_sources))
+        errstream.write('Source(s) that support this node: {}\n'.format(' '.join([str(i) for i in mrca_node.synth_sources])))
         errstream.write('Is in the synthetic tree of life? {}\n'.format(mrca_node.in_synth_tree))
         errstream.write('Correspondences with other taxonomies: {}\n'.format(mrca_node.tax_source))
         errstream.write('Is in the graph of life? {}\n'.format(mrca_node.in_graph))


### PR DESCRIPTION
This was started as a branch to add some functionality to the OTT wrapper (peyotl/ott/__init__.py) for queries on a local copy of OTT. That code is not used in the peyotl-dependent infrastructure.

While working on that, I noticed and cleaned up some issues with the wrappers around the API and the tutorials.  I should have put those on a separate branch. they also do not affect deployed services.

There was one bug fix (see nexson_syntax below)

The summary:

  * peyotl/ott/__init__.py support for writing OTT subtrees in newick; looking up an OTT ID from an NCBI taxonomy ID; and the ability to detect taxa that match one of a set of flags.

  * peyotl/api/{taxomachine | taxon | treemachine}.py reducing code duplication by a new TaxonHolder class

  * peyotl/manip.py new function for iterating over otus in a study

  * peyotl/nexson_syntax/__init__.py bug fix - now correctly emits newicks even if they have labels that require the use of unicode strings in python 2. Not many OTT IDs need this. I'm not sure if any of the studies in phylesystem map to those studies. So this may not have caused any problems. I discovered it while implementing the newick export of OTT

  * peyotl/utility/dict_wrapper.py better formatting as string - this class is just used by API wrappers at this point.

  * tutorials/* examples/* new example scripts

  * maintainer-tests.sh and tutorial-tests.sh new tests that make sure the tutorials work. Called by the maintainer-tests now.
