### PR TITLE
Opentree issue 641 [curator fails to add study in treebase]

### DIFF
--- a/examples/graph-of-life/list-synth-sources.py
+++ b/examples/graph-of-life/list-synth-sources.py
@@ -21,6 +21,8 @@ parser.add_argument('--nexus',
                     help="(if --fetch is used). format results as NEXUS")
 args = parser.parse_args(sys.argv[1:])
 download = args.fetch
+if download:
+    sys.exit('The fetch option is no longer supported because of https://github.com/OpenTreeOfLife/treemachine/issues/170\n')
 nexus = args.nexus
 out = sys.stdout
 

--- a/peyotl/api/treemachine.py
+++ b/peyotl/api/treemachine.py
@@ -222,21 +222,22 @@ class _TreemachineAPIWrapper(_WSWrapper):
     def synthetic_source_list(self):
         uri = '{p}/getSynthesisSourceList'.format(p=self.prefix)
         return self.json_http_post_raise(uri)
+    # deprecated due to https://github.com/OpenTreeOfLife/treemachine/issues/170
     # format is redefined to match API
     #pylint: disable=W0622
-    def get_source_tree(self, tree_id=None, format='newick', node_id=None, max_depth=None, **kwargs):
-        if self.use_v1:
-            uri = '{p}/getSourceTree'.format(p=self.prefix)
-            return self._get_tree(uri, tree_id, format=format, node_id=node_id, max_depth=max_depth)
-        else:
-            uri = '{p}/source_tree'.format(p=self.graph_prefix)
-            study_id = kwargs.get('study_id', '')
-            if len(study_id) < 3 or study_id[2] != '_':
-                study_id = 'pg_' + study_id
-            data = {'git_sha': kwargs.get('git_sha', ''),
-                    'study_id': study_id,
-                    'tree_id': tree_id}
-            return self.json_http_post_raise(uri, data=anyjson.dumps(data))
+    #def get_source_tree(self, tree_id=None, format='newick', node_id=None, max_depth=None, **kwargs):
+    #    if self.use_v1:
+    #        uri = '{p}/getSourceTree'.format(p=self.prefix)
+    #        return self._get_tree(uri, tree_id, format=format, node_id=node_id, max_depth=max_depth)
+    #    else:
+    #        uri = '{p}/source_tree'.format(p=self.graph_prefix)
+    #        study_id = kwargs.get('study_id', '')
+    #        if len(study_id) < 3 or study_id[2] != '_':
+    #            study_id = 'pg_' + study_id
+    #        data = {'git_sha': kwargs.get('git_sha', ''),
+    #                'study_id': study_id,
+    #                'tree_id': tree_id}
+    #        return self.json_http_post_raise(uri, data=anyjson.dumps(data))
     def get_synthetic_tree(self, tree_id=None, format='newick', node_id=None, max_depth=None, ott_id=None): #pylint: disable=W0622
         if self.use_v1:
             uri = '{p}/getSyntheticTree'.format(p=self.prefix)

--- a/peyotl/api/wrapper.py
+++ b/peyotl/api/wrapper.py
@@ -104,6 +104,9 @@ def get_domains_obj(**kwargs):
     return api_domains
 
 class APIWrapper(object):
+    # deprecated service
+    # see https://github.com/OpenTreeOfLife/treemachine/issues/170
+    SUPPORTING_GET_SOURCE_TREE = False
     def __init__(self, domains=None, phylesystem_api_kwargs=None, **kwargs):
         if domains is None:
             domains = get_domains_obj(**kwargs)
@@ -278,8 +281,9 @@ class _GraphOfLifeServicesWrapper(object):
     def info(self):
         return self.treemachine.graph_info
     about = info
-    def source_tree(self, *valist, **kwargs):
-        return self.treemachine.get_source_tree(*valist, **kwargs)
+    # deprecated due to https://github.com/OpenTreeOfLife/treemachine/issues/170
+    #def source_tree(self, *valist, **kwargs):
+    #    return self.treemachine.get_source_tree(*valist, **kwargs)
     def node_info(self, *valist, **kwargs):
         return self.treemachine.node_info(*valist, **kwargs)
 

--- a/peyotl/external.py
+++ b/peyotl/external.py
@@ -201,5 +201,9 @@ def get_ot_study_info_from_treebase_nexml(src=None,
 def import_nexson_from_treebase(treebase_id,
                                 nexson_syntax_version=DEFAULT_NEXSON_VERSION):
     url = _get_treebase_url(treebase_id)
-    return get_ot_study_info_from_treebase_nexml(src=url,
-                                                 nexson_syntax_version=nexson_syntax_version)
+    try:
+        return get_ot_study_info_from_treebase_nexml(src=url,
+                                                     nexson_syntax_version=nexson_syntax_version)
+    except Exception as x:
+        _LOG.exception('Error parsing NeXML from {}'.format(url))
+        raise

--- a/peyotl/nexson_syntax/direct2optimal_nexson.py
+++ b/peyotl/nexson_syntax/direct2optimal_nexson.py
@@ -79,10 +79,17 @@ class Direct2OptimalNexson(NexsonConverter):
         tree['^ot:rootNodeId'] = root_node['@id']
         # Make the struct leaner
         tid = tree['@id']
+        _LOG.warn('tid = {}'.format(tid))
+        _LOG.warn('tree.keys = {}'.format(tree.keys()))
         if self.remove_old_structs:
             del tree['@id']
             del tree['node']
-            del tree['edge']
+            try:
+                del tree['edge']
+            except:
+                # Tree Tr75035 in http://treebase.org/treebase-web/search/study/summary.html?id=14763
+                #   is empty. in NeXML that shows up as a tree with a node but no edges
+                pass 
             for node in node_list:
                 if '^ot:isLeaf' in node:
                     del node['^ot:isLeaf']

--- a/peyotl/test/test_external.py
+++ b/peyotl/test/test_external.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python
+from peyotl.external import get_ot_study_info_from_treebase_nexml
+from peyotl.test.support import pathmap
+from peyotl import write_as_json
+from peyotl.utility import get_logger
+import unittest
+import codecs
+_LOG = get_logger(__name__)
+
+class TestExternal(unittest.TestCase):
+    pass
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        with codecs.open(sys.argv[1], 'r', encoding='utf-8') as inp:
+            content = inp.read()
+        b = get_ot_study_info_from_treebase_nexml(nexml_content=content)
+        write_as_json(b, sys.stdout)
+    #unittest.main()

--- a/peyotl/test/test_treemachine.py
+++ b/peyotl/test/test_treemachine.py
@@ -14,9 +14,10 @@ class TestTreemachine(unittest.TestCase):
     def testSourceTree(self):
         source_id_list = self.treemachine.synthetic_tree_id_list
         self.assertTrue(isinstance(source_id_list, list))
-        f = source_id_list[0]
-        r = self.treemachine.get_source_tree(**f)
-        self.assertTrue(r['newick'].startswith('('))
+        # commented out due to https://github.com/OpenTreeOfLife/treemachine/issues/170
+        #f = source_id_list[0]
+        #r = self.treemachine.get_source_tree(**f)
+        #self.assertTrue(r['newick'].startswith('('))
     def testSynthTree(self):
         cdict = self.treemachine.synthetic_tree_info
         if self.treemachine.use_v1:

--- a/peyotl/test/test_v2facade.py
+++ b/peyotl/test/test_v2facade.py
@@ -81,9 +81,10 @@ class TestOTI(unittest.TestCase):
     def testSourceTree(self):
         source_id_list = self.ot.tree_of_life.about()['study_list']
         self.assertTrue(isinstance(source_id_list, list))
-        f = source_id_list[0]
-        r = self.ot.graph.source_tree(**f)
-        self.assertTrue(r['newick'].startswith('('))
+        # commented out due to https://github.com/OpenTreeOfLife/treemachine/issues/170
+        #f = source_id_list[0]
+        #r = self.ot.graph.source_tree(**f)
+        #self.assertTrue(r['newick'].startswith('('))
     def testSynthTree(self):
         cdict = self.ot.tree_of_life.about()
         tree_id, node_id = _test_tol_about(self, cdict)


### PR DESCRIPTION
This should fix https://github.com/OpenTreeOfLife/opentree/issues/641
I tested this on a local version of the phylesystem-api.

Deals with empty trees in a treebase NeXML by skipping over those tree.  In some cases that could cause dangling references to those tree's IDs. But I think that these trees are probably all cases of TreeBASE submission errors or TreeBASE software bugs.

This PR should make https://github.com/OpenTreeOfLife/phylesystem-api/pull/151 unnecessary - at least for this particular case of this issue. (but that PR is just defensive coding which should have been done originally).