### PR TITLE
Fixes for support scripts (#134)

### DIFF
--- a/peyotl/phylesystem/phylesystem_umbrella.py
+++ b/peyotl/phylesystem/phylesystem_umbrella.py
@@ -118,6 +118,9 @@ class _Phylesystem(TypeAwareDocStore):
     @property
     def iter_study_objs(self):
         return self.iter_doc_objs
+    @property
+    def iter_study_filepaths(self):
+        return self.iter_doc_filepaths
 
     @property
     def new_study_prefix(self):

--- a/peyotl/phylesystem/phylesystem_umbrella.py
+++ b/peyotl/phylesystem/phylesystem_umbrella.py
@@ -115,6 +115,9 @@ class _Phylesystem(TypeAwareDocStore):
     @property
     def push_study_to_remote(self):
         return self.push_doc_to_remote
+    @property
+    def iter_study_objs(self):
+        return self.iter_doc_objs
 
     @property
     def new_study_prefix(self):

--- a/peyotl/test/test_phylesystem.py
+++ b/peyotl/test/test_phylesystem.py
@@ -52,11 +52,11 @@ class TestPhylesystem(unittest.TestCase):
     def testChangedStudies(self):
         p = _Phylesystem(repos_dict=self.r)
         p.pull()  # get the full git history
-        changed = p.get_changed_studies('2d59ab892ddb3d09d4b18c91470b8c1c4cca86dc')
+        changed = p.get_changed_studies('5f50b669cb4867d39e9a85e7fd1e2aa8e9a3242b')
         self.assertEqual(set(['xy_13', 'xy_10']), changed)
-        changed = p.get_changed_studies('2d59ab892ddb3d09d4b18c91470b8c1c4cca86dc', ['zz_11'])
+        changed = p.get_changed_studies('5f50b669cb4867d39e9a85e7fd1e2aa8e9a3242b', ['zz_11'])
         self.assertEqual(set(), changed)
-        changed = p.get_changed_studies('2d59ab892ddb3d09d4b18c91470b8c1c4cca86dc', ['zz_112'])
+        changed = p.get_changed_studies('5f50b669cb4867d39e9a85e7fd1e2aa8e9a3242b', ['zz_112'])
         self.assertEqual(set(), changed)
         self.assertRaises(ValueError, p.get_changed_studies, 'bogus')
     def testIterateStudies(self):

--- a/peyotl/test/test_phylesystem.py
+++ b/peyotl/test/test_phylesystem.py
@@ -1,4 +1,8 @@
 #! /usr/bin/env python
+
+# put tests here that use local phylesystem
+# see http://opentreeoflife.github.io/peyotl/maintainer/ for setup
+
 from peyotl.utility.input_output import read_as_json
 from peyotl.phylesystem.phylesystem_umbrella import _Phylesystem
 import unittest
@@ -55,6 +59,17 @@ class TestPhylesystem(unittest.TestCase):
         changed = p.get_changed_studies('2d59ab892ddb3d09d4b18c91470b8c1c4cca86dc', ['zz_112'])
         self.assertEqual(set(), changed)
         self.assertRaises(ValueError, p.get_changed_studies, 'bogus')
+    def testIterateStudies(self):
+        p = _Phylesystem(repos_dict=self.r)
+        k = list(p.get_study_ids())
+        count = 0
+        for study_id, file_path in p.iter_study_filepaths():
+            count+=1
+        self.assertEqual(count,len(k))
+        count = 0
+        for study_id, n in p.iter_study_objs():
+            count+=1
+        self.assertEqual(count,len(k))
 
 
 if __name__ == "__main__":

--- a/scripts/phylesystem/ot_phylesystem_list_property_values.py
+++ b/scripts/phylesystem/ot_phylesystem_list_property_values.py
@@ -38,7 +38,11 @@ else:
 def process_val(v, id_str):
     if v is not None:
         if report_ids:
-            v_dict.setdefault(v, []).append(id_str)
+            try:
+                v_dict.setdefault(v, []).append(id_str)
+            except:
+                # not a hashable type! convert to string
+                v_dict.setdefault(str(v), []).append(id_str)
         elif summarize_as_set:
             v_dict[v] += 1
         else:

--- a/scripts/phylesystem/ot_phylesystem_list_study_filepaths.py
+++ b/scripts/phylesystem/ot_phylesystem_list_study_filepaths.py
@@ -3,6 +3,7 @@
 phylesystem directories that the peyotl library can 
 find (see README for discussion of configuration).
 '''
-from peyotl import phylesystem_study_paths
-for study_id, filepath in phylesystem_study_paths():
+from peyotl.phylesystem.phylesystem_umbrella import Phylesystem
+phy = Phylesystem()
+for study_id, filepath in phy.iter_study_filepaths():
     print(filepath)

--- a/scripts/phylesystem/ot_phylesystem_list_tags.py
+++ b/scripts/phylesystem/ot_phylesystem_list_tags.py
@@ -32,9 +32,13 @@ for study_id, n in phy.iter_study_objs():
             else:
                 tree_dict[t] += 1
 print '\nStudy tag counts:'
+if len(study_dict.items()) == 0:
+    print "No study tags found!"
 for k,v in study_dict.items():
     print k,'\t',v
 print '\nTree tag counts:'
+if len(tree_dict.items()) == 0:
+    print "No tree tags found!"
 for k,v in tree_dict.items():
     print k,'\t',v
 


### PR DESCRIPTION
Some of these scripts were not tested after the recent refactoring for collections. Others needed some polish to handle (for example) non-hashable Nexson property values.

See #134 for details.