### PR TITLE
Change studyid_treeid to studyid@treeid

### DIFF
--- a/scripts/collection_export.py
+++ b/scripts/collection_export.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# exports information from a collection
+# called by propinquity when building synthetic tree
+
 from peyotl import collection_to_included_trees, read_as_json
 
 if __name__ == '__main__':

--- a/scripts/collection_export.py
+++ b/scripts/collection_export.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         raise
     for d in included:
         if export == 'studyID_treeID':
-            print '_'.join([d['studyID'], d['treeID']])
+            print '@'.join([d['studyID'], d['treeID']])
         else:
             assert export == 'studyID'
             print d['studyID']

--- a/scripts/nexson/prune_to_clean_mapped.py
+++ b/scripts/nexson/prune_to_clean_mapped.py
@@ -365,7 +365,7 @@ if __name__ == '__main__':
     parser.add_argument('nexson',
                         nargs='*',
                         type=str,
-                        help='nexson files with the name pattern studyID_treeID.json')
+                        help='nexson files with the name pattern studyID@treeID.json')
     parser.add_argument('--input-dir',
                         default=None,
                         type=str,
@@ -375,7 +375,7 @@ if __name__ == '__main__':
                         default=None,
                         type=str,
                         required=False,
-                        help='a filepath to a file that holds the studyID_treeID "tag" for the inputs, one per line. ".json" will be appended to create the filenames.')
+                        help='a filepath to a file that holds the studyID@treeID "tag" for the inputs, one per line. ".json" will be appended to create the filenames.')
     parser.add_argument('--ott-dir',
                         default=None,
                         type=str,
@@ -438,10 +438,10 @@ if __name__ == '__main__':
         log_obj = {}
         inp_fn = os.path.split(inp)[-1]
         study_tree = '.'.join(inp_fn.split('.')[:-1]) # strip extension
-        x = study_tree.split('_')
-        if len(x) != 3:
-            sys.exit('Currently using the NexSON file name to indicate the tree via: studyID_treeID.json. Expected exactly 2 _ in the filename.\n')
-        tree_id = study_tree.split('_')[-1]
+        x = study_tree.split('@')
+        if len(x) != 2:
+            sys.exit('Currently using the NexSON file name to indicate the tree via: studyID@treeID.json. Expected exactly 1 @ in the filename.\n')
+        tree_id = study_tree.split('@')[-1]
         nexson_blob = read_as_json(inp)
         ntw = NexsonTreeWrapper(nexson_blob, tree_id, log_obj=log_obj)
         assert ntw.root_node_id

--- a/scripts/phylesystem/export_studies_from_collection.py
+++ b/scripts/phylesystem/export_studies_from_collection.py
@@ -30,7 +30,7 @@ def copy_phylesystem_file_if_differing(git_action,
     if not os.path.isfile(fp):
         debug(fp + ' does not exist')
         assert os.path.isfile(fp)
-    new_name = '{}_{}.json'.format(study_id, tree_id)
+    new_name = '{}@{}.json'.format(study_id, tree_id)
     np = os.path.join(out_dir, new_name)
     # create a new "decision" entry that is bound to this SHA
     concrete_coll_decision = copy.deepcopy(coll_decision)


### PR DESCRIPTION
Allows parsing of sourceid strings based separator; treeid will never contain '@' in valid NeXML. Affects propinquity and its outputs.

Related to https://github.com/OpenTreeOfLife/propinquity/pull/12

Addresses https://github.com/OpenTreeOfLife/propinquity/issues/4