### PR TITLE
dealing with False in boolean meta data

### DIFF
--- a/peyotl/nexson_syntax/nexson2nexml.py
+++ b/peyotl/nexson_syntax/nexson2nexml.py
@@ -36,7 +36,7 @@ def _create_sub_el(doc, parent, tag, attrib, data=None):
                 el.setAttribute(att_key, att_value)
     if parent:
         parent.appendChild(el)
-    if data:
+    if data is not None:
         if data is True:
             el.appendChild(doc.createTextNode('true'))
         elif data is False:


### PR DESCRIPTION
If data evaluates to boolean = false then
the NeXML output had been an empty element
rather than <meta ...>false</meta>