### PR TITLE
Coerce amendment DOIs to URLs

### DIFF
--- a/peyotl/amendments/amendments_umbrella.py
+++ b/peyotl/amendments/amendments_umbrella.py
@@ -230,7 +230,7 @@ class _TaxonomicAmendmentStore(TypeAwareDocStore):
 
                 # amendment is now in the repo, so we can safely reserve the ottids
                 first_minted_id, last_minted_id = self._growing_shard._mint_new_ott_ids(
-                    how_many=min(num_taxa_eligible_for_ids,1))
+                    how_many=max(num_taxa_eligible_for_ids,1))
                 # do a final check for errors!
                 try:
                     assert first_minted_id == first_new_id

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -2,7 +2,7 @@
 from peyotl.amendments.amendments_umbrella import TaxonomicAmendmentStore, TaxonomicAmendmentStoreProxy
 from peyotl.api.wrapper import _WSWrapper, APIWrapper
 from peyotl.amendments import AMENDMENT_ID_PATTERN
-from peyotl.utility import get_logger, doi2url
+from peyotl.utility import get_logger, coerce_amendment_dois_to_urls
 import anyjson
 import os
 _LOG = get_logger(__name__)
@@ -116,12 +116,12 @@ class _TaxonomicAmendmentsAPIWrapper(_WSWrapper):
             r = {'data': json}
         elif self._src_code == _GET_LOCAL:
             json, sha = self.docstore_obj.return_doc(amendment_id) #pylint: disable=W0632
+            coerce_amendment_dois_to_urls(json)  # normally done via API
             r = {'data': json,
                  'sha': sha}
         else:
             assert self._src_code == _GET_API
             r = self._remote_get_amendment(amendment_id)
-        self._coerce_source_dois_to_urls(r.get('data'))
         return r
     @property
     def auth_token(self):
@@ -147,29 +147,10 @@ variable to obtain this token. If you need to obtain your key, see the instructi
     def unmerged_branches(self):
         uri = '{}/amendments/unmerged_branches'.format(self._prefix)
         return self.json_http_get(uri)
-    def _coerce_source_dois_to_urls(self,
-                                    json):
-        # Convert source DOIs to their URL form (when fetching, saving, or
-        # updating an amendment)
-        if 'taxa' in json:
-            # simple amendment JSON
-            taxa = json.get('taxa')
-        else:
-            # JSON includes wrapper w/ history, etc.
-            taxa = json.get('data').get('taxa')
-        if isinstance(taxa, list):
-            for taxon in taxa:
-                sources = taxon.get('sources')
-                if isinstance(sources, list):
-                    for src in sources:
-                        if src.get('source_type') == "Link (DOI) to publication":
-                            doi = src.get('source', "")
-                            src['source'] = doi2url(doi)
     def post_amendment(self,
                        json,
                        commit_msg=None):
         assert json is not None
-        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment'.format(d=self._prefix)
         params = {'auth_token': self.auth_token}
         if commit_msg:
@@ -183,7 +164,6 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                       starting_commit_sha,
                       commit_msg=None):
         assert json is not None
-        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment/{i}'.format(d=self._prefix, i=amendment_id)
         params = {'starting_commit_SHA':starting_commit_sha,
                   'auth_token': self.auth_token}

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -2,7 +2,7 @@
 from peyotl.amendments.amendments_umbrella import TaxonomicAmendmentStore, TaxonomicAmendmentStoreProxy
 from peyotl.api.wrapper import _WSWrapper, APIWrapper
 from peyotl.amendments import AMENDMENT_ID_PATTERN
-from peyotl.utility import get_logger
+from peyotl.utility import get_logger, doi2url
 import anyjson
 import os
 _LOG = get_logger(__name__)
@@ -121,6 +121,7 @@ class _TaxonomicAmendmentsAPIWrapper(_WSWrapper):
         else:
             assert self._src_code == _GET_API
             r = self._remote_get_amendment(amendment_id)
+        self._coerce_source_dois_to_urls(r.get('data'))
         return r
     @property
     def auth_token(self):
@@ -146,10 +147,25 @@ variable to obtain this token. If you need to obtain your key, see the instructi
     def unmerged_branches(self):
         uri = '{}/amendments/unmerged_branches'.format(self._prefix)
         return self.json_http_get(uri)
+    def _coerce_source_dois_to_urls(self,
+                                    json):
+        # Convert source DOIs to their URL form (when fetching, saving, or
+        # updating an amendment)
+        taxa = json.get('taxa')
+        if isinstance(taxa, list):
+            for taxon in taxa:
+                sources = taxon.get('sources')
+                if isinstance(sources, list):
+                    for src in sources:
+                        if src.get('source_type') == "Link (DOI) to publication":
+                            doi = src.get('source', "")
+                            src.set('source', doi2url(doi) )
+
     def post_amendment(self,
                        json,
                        commit_msg=None):
         assert json is not None
+        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment'.format(d=self._prefix)
         params = {'auth_token': self.auth_token}
         if commit_msg:
@@ -163,6 +179,7 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                       starting_commit_sha,
                       commit_msg=None):
         assert json is not None
+        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment/{i}'.format(d=self._prefix, i=amendment_id)
         params = {'starting_commit_SHA':starting_commit_sha,
                   'auth_token': self.auth_token}

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -151,7 +151,12 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                                     json):
         # Convert source DOIs to their URL form (when fetching, saving, or
         # updating an amendment)
-        taxa = json.get('taxa')
+        if 'taxa' in json:
+            # simple amendment JSON
+            taxa = json.get('taxa')
+        else:
+            # JSON includes wrapper w/ history, etc.
+            taxa = json.get('data').get('taxa')
         if isinstance(taxa, list):
             for taxon in taxa:
                 sources = taxon.get('sources')
@@ -159,8 +164,7 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                     for src in sources:
                         if src.get('source_type') == "Link (DOI) to publication":
                             doi = src.get('source', "")
-                            src.set('source', doi2url(doi) )
-
+                            src['source'] = doi2url(doi)
     def post_amendment(self,
                        json,
                        commit_msg=None):

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -383,6 +383,24 @@ def doi2url(v):
         return 'http://dx.doi.org/' + v
     # convert anything else to URL and hope for the best
     return 'http://' + v
+def coerce_amendment_dois_to_urls(json):
+    # Convert source DOIs in a taxonomic amendment to URL form (when fetching,
+    # saving, or updating an amendment).
+    # N.B. `json` is actually a dict (parsed from amendment JSON)!
+    if 'taxa' in json:
+        # simple amendment JSON
+        taxa = json.get('taxa')
+    else:
+        # JSON includes wrapper w/ history, etc.
+        taxa = json.get('data').get('taxa')
+    if isinstance(taxa, list):
+        for taxon in taxa:
+            sources = taxon.get('sources')
+            if isinstance(sources, list):
+                for src in sources:
+                    if src.get('source_type') == "Link (DOI) to publication":
+                        doi = src.get('source', "")
+                        src['source'] = doi2url(doi)
 def get_unique_filepath(stem):
     '''NOT thread-safe!
     return stems or stem# where # is the smallest

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -379,7 +379,10 @@ def doi2url(v):
         v = v[5:] # trim 'doi: '
     if v.startswith('doi:'):
         v = v[4:] # trim 'doi:'
-    return 'http://dx.doi.org/' + v
+    if v.startswith('10.'):  # it's a DOI!
+        return 'http://dx.doi.org/' + v
+    # convert anything else to URL and hope for the best
+    return 'http://' + v
 def get_unique_filepath(stem):
     '''NOT thread-safe!
     return stems or stem# where # is the smallest

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -375,8 +375,10 @@ get_config_var = get_config
 def doi2url(v):
     if v.startswith('http'):
         return v
+    if v.startswith('doi: '):
+        v = v[5:] # trim 'doi: '
     if v.startswith('doi:'):
-        v = v[4:] # trim doi:
+        v = v[4:] # trim 'doi:'
     return 'http://dx.doi.org/' + v
 def get_unique_filepath(stem):
     '''NOT thread-safe!


### PR DESCRIPTION
This is done when fetching, adding, or updating a taxonomic amendment via the API (so it "repairs" old amendments on the fly). Addresses #155.