### PR TITLE
Remove doi coercion

### DIFF
--- a/peyotl/amendments/validation/adaptor.py
+++ b/peyotl/amendments/validation/adaptor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """AmendmentValidationAdaptor class.
 """
-from peyotl.utility import get_logger
+from peyotl.utility import get_logger, doi2url
 
 _LOG = get_logger(__name__)
 
@@ -188,6 +188,10 @@ class AmendmentValidationAdaptor(object):
                 self.source_types_not_requiring_value = [
                     'The taxon is described in this study',
                 ]
+                self.source_types_requiring_URL = [
+                    'Link to online taxonomy',
+                    'Link (DOI) to publication',
+                ]
                 valid_source_found = False
                 if len(taxon.get('sources')) > 0:
                     for s in taxon.get('sources'):
@@ -204,6 +208,13 @@ class AmendmentValidationAdaptor(object):
                                     errors.append("Missing value for taxon source of type '{t}'!".format(t=s_type))
                             else:
                                 valid_source_found = True
+                            if s_type in self.source_types_requiring_URL:
+                                try:
+                                    # its value should contain a URL (ie, conversion does nothing)
+                                    s_val = s.get('source')
+                                    assert s_val == doi2url(s_val)
+                                except:
+                                    errors.append("Source '{s}' (of type '{t}') should be a URL!".format(s=s_val, t=s_type))
                         except:
                             errors.append("Unknown taxon source type '{t}'!".format(t=s_type))
 

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -126,7 +126,7 @@ class _TaxonomicAmendmentsAPIWrapper(_WSWrapper):
             json = self.json_http_get(url)
             r = {'data': json}
         elif self._src_code == _GET_LOCAL:
-            json, sha = self.docstore_obj.return_doc(amendment_id) #pylint: disable=W0632
+            json, sha = self.docstore_obj.return_doc(amendment_id)  #pylint: disable=W0632
             r = {'data': json,
                  'sha': sha}
         else:
@@ -161,6 +161,7 @@ variable to obtain this token. If you need to obtain your key, see the instructi
     def unmerged_branches(self):
         uri = '{}/amendments/unmerged_branches'.format(self._prefix)
         return self.json_http_get(uri)
+
     def post_amendment(self,
                        json,
                        commit_msg=None):

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -166,12 +166,7 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                                     json):
         # Convert source DOIs to their URL form (when fetching, saving, or
         # updating an amendment)
-        if 'taxa' in json:
-            # simple amendment JSON
-            taxa = json.get('taxa')
-        else:
-            # JSON includes wrapper w/ history, etc.
-            taxa = json.get('data').get('taxa')
+        taxa = json.get('taxa')
         if isinstance(taxa, list):
             for taxon in taxa:
                 sources = taxon.get('sources')
@@ -179,7 +174,8 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                     for src in sources:
                         if src.get('source_type') == "Link (DOI) to publication":
                             doi = src.get('source', "")
-                            src['source'] = doi2url(doi)
+                            src.set('source', doi2url(doi) )
+
     def post_amendment(self,
                        json,
                        commit_msg=None):

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -2,7 +2,7 @@
 from peyotl.amendments.amendments_umbrella import TaxonomicAmendmentStore, TaxonomicAmendmentStoreProxy
 from peyotl.api.wrapper import _WSWrapper, APIWrapper
 from peyotl.amendments import AMENDMENT_ID_PATTERN
-from peyotl.utility import get_logger, doi2url
+from peyotl.utility import get_logger
 import anyjson
 import os
 
@@ -132,7 +132,6 @@ class _TaxonomicAmendmentsAPIWrapper(_WSWrapper):
         else:
             assert self._src_code == _GET_API
             r = self._remote_get_amendment(amendment_id)
-        self._coerce_source_dois_to_urls(r.get('data'))
         return r
 
     @property
@@ -162,25 +161,10 @@ variable to obtain this token. If you need to obtain your key, see the instructi
     def unmerged_branches(self):
         uri = '{}/amendments/unmerged_branches'.format(self._prefix)
         return self.json_http_get(uri)
-    def _coerce_source_dois_to_urls(self,
-                                    json):
-        # Convert source DOIs to their URL form (when fetching, saving, or
-        # updating an amendment)
-        taxa = json.get('taxa')
-        if isinstance(taxa, list):
-            for taxon in taxa:
-                sources = taxon.get('sources')
-                if isinstance(sources, list):
-                    for src in sources:
-                        if src.get('source_type') == "Link (DOI) to publication":
-                            doi = src.get('source', "")
-                            src.set('source', doi2url(doi) )
-
     def post_amendment(self,
                        json,
                        commit_msg=None):
         assert json is not None
-        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment'.format(d=self._prefix)
         params = {'auth_token': self.auth_token}
         if commit_msg:
@@ -195,7 +179,6 @@ variable to obtain this token. If you need to obtain your key, see the instructi
                       starting_commit_sha,
                       commit_msg=None):
         assert json is not None
-        self._coerce_source_dois_to_urls(json)
         uri = '{d}/amendment/{i}'.format(d=self._prefix, i=amendment_id)
         params = {'starting_commit_SHA': starting_commit_sha,
                   'auth_token': self.auth_token}

--- a/peyotl/api/amendments_api.py
+++ b/peyotl/api/amendments_api.py
@@ -126,7 +126,7 @@ class _TaxonomicAmendmentsAPIWrapper(_WSWrapper):
             json = self.json_http_get(url)
             r = {'data': json}
         elif self._src_code == _GET_LOCAL:
-            json, sha = self.docstore_obj.return_doc(amendment_id)  #pylint: disable=W0632
+            json, sha = self.docstore_obj.return_doc(amendment_id)  # pylint: disable=W0632
             r = {'data': json,
                  'sha': sha}
         else:

--- a/peyotl/test/data/amendments/amendment-bad-dois.json
+++ b/peyotl/test/data/amendments/amendment-bad-dois.json
@@ -1,0 +1,24 @@
+{
+    "user_agent": "opentree-reference-taxonomy",
+    "id": "additions-1234567-12345678",
+    "curator": {
+        "login": "jimallman", 
+        "name": "Jim Allman"
+    },
+    "date_created": "2015-09-23T15:27:43.298Z",
+    "study_id": "ot_234",
+    "taxa": [
+        {
+            "name": "",
+            "parent": 1,
+            "name": "",
+            "name_derivation": "",
+            "sources": [
+                {
+                    "source_type": "Link (DOI) to publication",
+                    "source": "10.123"
+                }
+            ]
+        }
+    ]
+}

--- a/peyotl/test/test_amendment_validation.py
+++ b/peyotl/test/test_amendment_validation.py
@@ -33,17 +33,30 @@ class TestAmendmentValidator(unittest.TestCase):
         msg = ''
         frag = 'amendment-incomplete.json'
         inp = pathmap.amendment_obj(frag)
-        try:
-            aa = validate_amendment(inp)
-            if len(aa) > 0:
-                errors = aa[0]
-                if len(errors) == 0:
-                    ofn = pathmap.amendment_source_path(frag + '.output')
-                    testing_write_json(errors, ofn)
-                    msg = "Failed to reject file. See {o}".format(o=str(msg))
-                    self.assertTrue(False, msg)
-        except:
-            pass
+        aa = validate_amendment(inp)
+        if len(aa) > 0:
+            errors = aa[0]
+            if len(errors) == 0:
+                ofn = pathmap.amendment_source_path(frag + '.output')
+                testing_write_json(errors, ofn)
+                msg = "Failed to reject invalid file (no errors found)"
+                self.assertTrue(False, msg)
+
+    def testInvalidDOIsFail(self):
+        # all DOIs should be in URL form
+        msg = ''
+        frag = 'amendment-bad-dois.json'
+        inp = pathmap.amendment_obj(frag)
+        aa = validate_amendment(inp)
+        if len(aa) > 0:
+            errors = aa[0]
+            ofn = pathmap.amendment_source_path(frag + '.output')
+            testing_write_json(errors, ofn)
+            if len(errors) == 0:
+                msg = "Failed to reject bare DOI (no errors found)"
+                self.assertTrue(False, msg)
+            else:
+                self.assertTrue('should be a URL' in errors[0])
 
     def testExpectedWarnings(self):
         msg = ''

--- a/peyotl/utility/__init__.py
+++ b/peyotl/utility/__init__.py
@@ -46,26 +46,6 @@ def doi2url(v):
     return 'http://' + v
 
 
-def coerce_amendment_dois_to_urls(json):
-    # Convert source DOIs in a taxonomic amendment to URL form (when fetching,
-    # saving, or updating an amendment).
-    # N.B. `json` is actually a dict (parsed from amendment JSON)!
-    if 'taxa' in json:
-        # simple amendment JSON
-        taxa = json.get('taxa')
-    else:
-        # JSON includes wrapper w/ history, etc.
-        taxa = json.get('data').get('taxa')
-    if isinstance(taxa, list):
-        for taxon in taxa:
-            sources = taxon.get('sources')
-            if isinstance(sources, list):
-                for src in sources:
-                    if src.get('source_type') == "Link (DOI) to publication":
-                        # noinspection PyTypeChecker
-                        src['source'] = doi2url(src.get('source', ""))
-
-
 def get_unique_filepath(stem):
     """NOT thread-safe!
     return stems or stem# where # is the smallest


### PR DESCRIPTION
Cleanup of unwanted code that coerces amendment DOIs to URLs in peyotl. (The main PR was rejected, but its code was pulled into other feature branches.)