### PR TITLE
Include exclude trees in synth

### DIFF
--- a/peyotl/__init__.py
+++ b/peyotl/__init__.py
@@ -14,7 +14,9 @@ from peyotl.utility import (get_config_setting,
                             get_logger)
 from peyotl.utility.input_output import pretty_dict_str
 
-from peyotl.collections_store import collection_to_included_trees, concatenate_collections
+from peyotl.collections_store import (collection_to_included_trees,
+                                      concatenate_collections,
+                                      tree_is_in_collection)
 from peyotl.nexson_syntax import (can_convert_nexson_forms,
                                   convert_nexson_format,
                                   detect_nexson_version,

--- a/peyotl/collections_store/__init__.py
+++ b/peyotl/collections_store/__init__.py
@@ -42,6 +42,17 @@ def collection_to_included_trees(collection):
             inc.append(d)
     return inc
 
+def tree_is_in_collection(collection, study_id=None, tree_id=None):
+    """Takes a collection object (or a filepath to collection object), returns
+    True if it includes a decision to include the specified tree
+    """
+    included = collection_to_included_trees(collection)
+    study_id = study_id.strip()
+    tree_id = tree_id.strip()
+    for decision in included:
+        if decision['studyID'] == study_id and decision['treeID'] == tree_id:
+            return True
+    return False
 
 def concatenate_collections(collection_list):
     r = get_empty_collection()

--- a/peyotl/collections_store/collections_umbrella.py
+++ b/peyotl/collections_store/collections_umbrella.py
@@ -201,7 +201,6 @@ class _TreeCollectionStore(TypeAwareDocStore):
         if collection is None:
             msg = "File failed to parse as JSON:\n{j}".format(j=json_repr)
             raise ValueError(msg)
-        _LOG.exception('BEFORE validation')
         if not self._is_valid_collection_json(collection):
             msg = "JSON is not a valid collection:\n{j}".format(j=json_repr)
             raise ValueError(msg)
@@ -255,18 +254,14 @@ class _TreeCollectionStore(TypeAwareDocStore):
 
     def _is_valid_collection_json(self, json_repr):
         """Call the primary validator for a quick test"""
-        _LOG.exception('BEFORE coercion')
         collection = self._coerce_json_to_collection(json_repr)
-        _LOG.exception('AFTER coercion')
-        _LOG.exception(collection)
         if collection is None:
             # invalid JSON, definitely broken
             return False
         aa = validate_collection(collection)
         errors = aa[0]
         for e in errors:
-            #_LOG.debug('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
-            _LOG.exception('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
+            _LOG.debug('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
         if len(errors) > 0:
             return False
         return True

--- a/peyotl/collections_store/collections_umbrella.py
+++ b/peyotl/collections_store/collections_umbrella.py
@@ -214,7 +214,8 @@ class _TreeCollectionStore(TypeAwareDocStore):
         r = None
         try:
             # remove any 'url' field before saving; it will be restored when the doc is fetched (via API)
-            del collection['url']
+            if 'url' in collection:
+                del collection['url']
             # keep it simple (collection is already validated! no annotations needed!)
             r = self.commit_and_try_merge2master(file_content=collection,
                                                  doc_id=collection_id,

--- a/peyotl/collections_store/collections_umbrella.py
+++ b/peyotl/collections_store/collections_umbrella.py
@@ -201,6 +201,7 @@ class _TreeCollectionStore(TypeAwareDocStore):
         if collection is None:
             msg = "File failed to parse as JSON:\n{j}".format(j=json_repr)
             raise ValueError(msg)
+        _LOG.exception('BEFORE validation')
         if not self._is_valid_collection_json(collection):
             msg = "JSON is not a valid collection:\n{j}".format(j=json_repr)
             raise ValueError(msg)
@@ -253,14 +254,18 @@ class _TreeCollectionStore(TypeAwareDocStore):
 
     def _is_valid_collection_json(self, json_repr):
         """Call the primary validator for a quick test"""
+        _LOG.exception('BEFORE coercion')
         collection = self._coerce_json_to_collection(json_repr)
+        _LOG.exception('AFTER coercion')
+        _LOG.exception(collection)
         if collection is None:
             # invalid JSON, definitely broken
             return False
         aa = validate_collection(collection)
         errors = aa[0]
         for e in errors:
-            _LOG.debug('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
+            #_LOG.debug('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
+            _LOG.exception('> invalid JSON: {m}'.format(m=e.encode('utf-8')))
         if len(errors) > 0:
             return False
         return True

--- a/peyotl/collections_store/validation/adaptor.py
+++ b/peyotl/collections_store/validation/adaptor.py
@@ -29,7 +29,6 @@ class CollectionValidationAdaptor(object):
         self.required_toplevel_elements = {
             # N.B. anyjson might parse a text element as str or unicode,
             # depending on its value. Either is fine here.
-            'url': string_types,
             'name': string_types,
             'description': string_types,
             'creator': dict,
@@ -37,23 +36,21 @@ class CollectionValidationAdaptor(object):
             'decisions': list,
             'queries': list,
         }
-        # currently all allowed elements are also required
-        # self.optional_toplevel_elements = {}
+        self.optional_toplevel_elements = {
+            'url': string_types,
+            # N.B. 'url' is stripped in storage, restored for API consumers
+        }
         # track unknown keys in top-level object
         uk = None
         for k in obj.keys():
-            if k not in self.required_toplevel_elements.keys():
+            if (k not in self.required_toplevel_elements.keys() and
+                        k not in self.optional_toplevel_elements.keys()):
                 if uk is None:
                     uk = []
                 uk.append(k)
         if uk:
             uk.sort()
-            # self._warn_event(_NEXEL.TOP_LEVEL,
-            #                  obj=obj,
-            #                  err_type=gen_UnrecognizedKeyWarning,
-            #                  anc=_EMPTY_TUPLE,
-            #                  obj_nex_id=None,
-            #                  key_list=uk)
+            errors.append("Found these unexpected taxon properties: {k}".format(k=uk))
 
         # test for existence and types of all required elements
         for el_key, el_type in self.required_toplevel_elements.items():


### PR DESCRIPTION
Add support functions for managing trees queued for synthesis, plus fixes to collection validation, etc. See commit messages for more detail.

These changes are live on **devapi**.