### PR TITLE
Coerce TreeBASE DOIs to URLs

### DIFF
--- a/peyotl/external.py
+++ b/peyotl/external.py
@@ -8,7 +8,7 @@ from peyotl.nexson_syntax import (get_ot_study_info_from_nexml,
                                   convert_nexson_format,
                                   sort_arbitrarily_ordered_nexson)
 from peyotl.nexson_syntax.helper import _simplify_all_meta_by_id_del
-from peyotl.utility import get_logger
+from peyotl.utility import get_logger, doi2url
 
 _LOG = get_logger(__name__)
 
@@ -82,6 +82,7 @@ def get_ot_study_info_from_treebase_nexml(src=None,
         nexml['^ot:studyPublicationReference'] = bd
     doi = nexml.get('^prism:doi')
     if doi:
+        doi = doi2url(doi)
         nexml['^ot:studyPublication'] = {'@href': doi}
     year = nexml.get('^prism:publicationDate')
     if year:

--- a/peyotl/test/data/nexson/S15515.json
+++ b/peyotl/test/data/nexson/S15515.json
@@ -56,7 +56,7 @@
 "Tls36428"
 ], 
 "^ot:studyPublication": {
-"@href": "10.1071/IS12017"
+"@href": "http://dx.doi.org/10.1071/IS12017"
 }, 
 "^ot:studyPublicationReference": "Bayer S., & Sch?nhofer A.L. 2013. Phylogenetic relationships of the spider family Psechridae inferred from molecular data, with comments on the Lycosoidea (Arachnida : Araneae). Invertebrate Systematics, 27: 53-80.", 
 "^ot:studyYear": 2013, 

--- a/tests/ws_tests/read_only/test_treebase_import.py
+++ b/tests/ws_tests/read_only/test_treebase_import.py
@@ -2,7 +2,7 @@
 from peyotl.external import get_ot_study_info_from_treebase_nexml
 from peyotl.test.support import equal_blob_check
 from peyotl.test.support import pathmap
-from peyotl.utility import get_logger
+from peyotl.utility import get_logger, doi2url
 
 _LOG = get_logger(__name__)
 import unittest
@@ -18,6 +18,11 @@ class TestConvert(unittest.TestCase):
         n = get_ot_study_info_from_treebase_nexml(src=fp,
                                                   merge_blocks=True,
                                                   sort_arbitrary=True)
+        # did we successfully coerce its DOI to the required URL form?
+        self.assertTrue('@href' in n['nexml']['^ot:studyPublication'])
+        test_doi = n['nexml']['^ot:studyPublication']['@href']
+        self.assertTrue(test_doi == doi2url(test_doi))
+        # furthermore, the output should exactly match our test file
         expected = pathmap.nexson_obj('S15515.json')
         equal_blob_check(self, 'S15515', n, expected)
         self.assertTrue(expected == n)


### PR DESCRIPTION
@mtholder, please take a look when you have a chance (and apologies if this is difficult to apply on top of recent refactoring). As [@jar398 points out](https://github.com/OpenTreeOfLife/peyotl/issues/138#issuecomment-250646496):

> The coercion should only happen when creating the nexson for a treebase study, not when the nexson comes from some other source. For other sources a valid nexson should be required (i.e. an invalid nexson should be rejected), and a valid nexson has URLs where URLs are expected.

I've made the change just to `get_ot_study_info_from_treebase_nexml`, so this should produce the desired behavior. Note that I've also updated the unit test for TreeBASE imports and our expected-result file. This PR partially fixes #138, https://github.com/OpenTreeOfLife/opentree/issues/907, and https://github.com/OpenTreeOfLife/clade-workshops/issues/5 ; in all cases, we really should also sweep the existing studies in https://github.com/opentreeoflife/phylesystem-1 and update any bare DOIs found there.