### PR TITLE
pin setuptools to fix use_2to3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ redis
 enum34
 argcomplete
 python-dateutil
-setuptools
+setuptools<58


### PR DESCRIPTION
https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2

Peyotl install was failing - pinning setup tools to an older version fixes it, but doesn't seem like a long term solution...